### PR TITLE
Make --series parameter required.

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -8,7 +8,7 @@
 # TODO: Reuse buildd environment if found.
 
 MINIMIZED=""
-SERIES="xenial"
+SERIES=""
 
 while :; do
     case "$1" in
@@ -34,6 +34,11 @@ while :; do
 
     shift
 done
+
+if [ x$SERIES = "x" ] ; then
+    echo "Missing required '--series' argument e.g. '--series xenial'"
+    exit 1
+fi
 
 DEPENDENCIES=(launchpad-buildd bzr python-ubuntutools)
 


### PR DESCRIPTION
Don't add a default. This avoids people from making assumptions about
what series the build will be for.