### PR TITLE
Remove hostname hack

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -131,10 +131,6 @@ export MIRROR=$(grep archive /etc/apt/sources.list|head -1 | \
 /usr/share/launchpad-buildd/slavebin/in-target update-debian-chroot \
   --backend=lxd --series=$SERIES --arch=amd64 $LIVEFS_NAME
 
-# Change the hostname to keep livecd-rootfs from mistaking this
-# as a buildd and setting the mirror url to ftpinternal
-lxc exec lp-$SERIES-amd64 -- hostname standalone-lp-$SERIES-amd64
-
 # Inject the files from the current tree in the right place in the LXD
 # container.
 # First install livecd-rootfs. We will replace the bulk of the livecd-rootfs


### PR DESCRIPTION
Changing the hostname was included to work-around a livecd-rootfs issue where the hostname was used to set the ubuntu archive and it was setting it to ftpinternal.  That has been fixed and this can be removed.  Furthermore, at present gethostid() in cosmic libc is segfaulting presently in this environment with this set.