### PR TITLE
Update launchpad-buildd binary paths/names (issue #20)

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -116,10 +116,10 @@ fi
 sudo sed -i 's/ntp\.buildd/0\.pool\.ntp\.org/g' \
   /etc/launchpad-buildd/default
 
-/usr/share/launchpad-buildd/slavebin/slave-prep
-/usr/share/launchpad-buildd/slavebin/in-target unpack-chroot --backend=lxd \
+/usr/share/launchpad-buildd/bin/builder-prep
+/usr/share/launchpad-buildd/bin/in-target unpack-chroot --backend=lxd \
   --series=$SERIES --arch=${ARCH} $LIVEFS_NAME $CHROOT_ARCHIVE
-/usr/share/launchpad-buildd/slavebin/in-target mount-chroot --backend=lxd \
+/usr/share/launchpad-buildd/bin/in-target mount-chroot --backend=lxd \
   --series=$SERIES --arch=${ARCH} $LIVEFS_NAME
 
 # Inject squid proxy config in the LXC if one exists in the host.
@@ -140,13 +140,13 @@ export MIRROR=$(egrep "(archive|ports)" /etc/apt/sources.list|head -1 | \
 export MIRROR_PATH=$(egrep "(archive|ports)" /etc/apt/sources.list|head -1 | \
                cut -d' ' -f2 | cut -d'/' -f4)
 
-/usr/share/launchpad-buildd/slavebin/in-target override-sources-list \
+/usr/share/launchpad-buildd/bin/in-target override-sources-list \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME \
     "deb http://$MIRROR/${MIRROR_PATH} $SERIES main restricted universe multiverse" \
     "deb http://$MIRROR/${MIRROR_PATH} $SERIES-security main restricted universe multiverse" \
     "deb http://$MIRROR/${MIRROR_PATH} $SERIES-updates main restricted universe multiverse"
 
-/usr/share/launchpad-buildd/slavebin/in-target update-debian-chroot \
+/usr/share/launchpad-buildd/bin/in-target update-debian-chroot \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME
 
 # Inject the files from the current tree in the right place in the LXD
@@ -166,7 +166,7 @@ lxc file push $OLD_FASHIONED_BUILD_CACHE/live-build.tar.gz lp-$SERIES-${ARCH}/us
 lxc exec lp-$SERIES-${ARCH} -- tar xzvf /usr/share/livecd-rootfs/live-build.tar.gz -C /usr/share/livecd-rootfs/
 
 # Actually build.
-time /usr/share/launchpad-buildd/slavebin/in-target buildlivefs \
+time /usr/share/launchpad-buildd/bin/in-target buildlivefs \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME $HTTP_PROXY \
   --project $PROJECT $MINIMIZED --datestamp $SERIAL --image-format ext4 \
   $IMAGE_TARGET
@@ -187,11 +187,11 @@ if [ $CLEANUP = false ] ; then
 fi
 
 # Cleanup the builder LXD.
-/usr/share/launchpad-buildd/slavebin/in-target scan-for-processes \
+/usr/share/launchpad-buildd/bin/in-target scan-for-processes \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME
 
-/usr/share/launchpad-buildd/slavebin/in-target umount-chroot \
+/usr/share/launchpad-buildd/bin/in-target umount-chroot \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME
 
-/usr/share/launchpad-buildd/slavebin/in-target remove-build \
+/usr/share/launchpad-buildd/bin/in-target remove-build \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME


### PR DESCRIPTION
launchpad-buildd v168 Moved /usr/share/launchpad-buildd/slavebin to
/usr/share/launchpad-buildd/bin.