### PR TITLE
Feature/point in time

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -14,6 +14,7 @@ SERIES=""
 USE_CHROOT_CACHE=false
 CLEANUP=true
 IMAGE_TARGET=""
+REPO_SNAPSHOT=""
 
 while :; do
     case "$1" in
@@ -51,6 +52,10 @@ while :; do
             ;;
         --image-target)
             IMAGE_TARGET="$IMAGE_TARGET --image-target $2"
+            shift
+            ;;
+        --repo-snapshot-stamp)
+            REPO_SNAPSHOT="--repo-snapshot-stamp $2"
             shift
             ;;
         -?*)
@@ -178,7 +183,7 @@ lxc exec lp-$SERIES-${ARCH} -- tar xzvf /usr/share/livecd-rootfs/live-build.tar.
 time /usr/share/launchpad-buildd/bin/in-target buildlivefs \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME $HTTP_PROXY \
   --project $PROJECT $SUBPROJECT --datestamp $SERIAL --image-format $IMG_FORMAT \
-  $IMAGE_TARGET
+  $IMAGE_TARGET $REPO_SNAPSHOT
 
 echo "Copying files out to $OUTPUT_DIRECTORY"
 rm -rf $OUTPUT_DIRECTORY

--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -15,6 +15,7 @@ USE_CHROOT_CACHE=false
 CLEANUP=true
 IMAGE_TARGET=""
 REPO_SNAPSHOT=""
+SNAP_COHORT=""
 
 while :; do
     case "$1" in
@@ -56,6 +57,10 @@ while :; do
             ;;
         --repo-snapshot-stamp)
             REPO_SNAPSHOT="--repo-snapshot-stamp $2"
+            shift
+            ;;
+        --snap-cohort-key)
+            SNAP_COHORT="--cohort-key $2"
             shift
             ;;
         -?*)
@@ -183,7 +188,7 @@ lxc exec lp-$SERIES-${ARCH} -- tar xzvf /usr/share/livecd-rootfs/live-build.tar.
 time /usr/share/launchpad-buildd/bin/in-target buildlivefs \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME $HTTP_PROXY \
   --project $PROJECT $SUBPROJECT --datestamp $SERIAL --image-format $IMG_FORMAT \
-  $IMAGE_TARGET $REPO_SNAPSHOT
+  $IMAGE_TARGET $REPO_SNAPSHOT $SNAP_COHORT
 
 echo "Copying files out to $OUTPUT_DIRECTORY"
 rm -rf $OUTPUT_DIRECTORY


### PR DESCRIPTION
* Add an option to pass a snap cohort key to builddlivefs.
* Add an option to to pass an apt repo timestamp to builddlivefs.

When these are used together with --image-target we can perform
parallel (or repeat) image builds which share a consistent view of the snap channel
map and the apt repo.