### PR TITLE
Support for interactive hook execution.

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -17,6 +17,7 @@ IMAGE_TARGET=""
 REPO_SNAPSHOT=""
 SNAP_COHORT=""
 INTERACTIVE_HOOKS=false
+HOOK_BASEDIR="hooks"
 
 while :; do
     case "$1" in
@@ -66,6 +67,9 @@ while :; do
             ;;
         --interactive-hooks)
             INTERACTIVE_HOOKS=true
+            ;;
+        --hook-basedir)
+            HOOK_BASEDIR="$2"
             shift
             ;;
         -?*)
@@ -129,6 +133,8 @@ if [ $INTERACTIVE_HOOKS = true ] ; then
     cp -aR ./ $LIVECD_ROOTFS_COPY
     cd $LIVECD_ROOTFS_COPY
 
+    rename 's/.binary$/.disabled/' $(find live-build -path "*$HOOK_BASEDIR/*.binary")
+
     cat > 001-debug.binary << "EOF"
 #!/bin/bash
 
@@ -149,8 +155,8 @@ do
 done > debug.in
 EOF
 
-    rename 's/.binary$/.binary.disabled/' $(find live-build -name '*.binary')
-    find live-build -type d -name 'hooks' -exec cp 001-debug.binary {} \;
+    chmod +x 001-debug.binary
+    find live-build -type d -name "$HOOK_BASEDIR" -exec cp 001-debug.binary {} \;
     rm 001-debug.binary
 fi
 

--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -16,6 +16,7 @@ CLEANUP=true
 IMAGE_TARGET=""
 REPO_SNAPSHOT=""
 SNAP_COHORT=""
+INTERACTIVE_HOOKS=false
 
 while :; do
     case "$1" in
@@ -61,6 +62,10 @@ while :; do
             ;;
         --snap-cohort-key)
             SNAP_COHORT="--cohort-key $2"
+            shift
+            ;;
+        --interactive-hooks)
+            INTERACTIVE_HOOKS=true
             shift
             ;;
         -?*)
@@ -110,6 +115,7 @@ set -xe
 
 OLD_FASHIONED_BUILD_CACHE="/tmp/old-fashioned-builder"
 UAT_CHECKOUT="$OLD_FASHIONED_BUILD_CACHE/uat"
+LIVECD_ROOTFS_COPY="$OLD_FASHIONED_BUILD_CACHE/livecd-rootfs"
 CHROOT_ARCHIVE_NAME="chroot-ubuntu-$SERIES-${ARCH}.tar.bz"
 CHROOT_ARCHIVE="$OLD_FASHIONED_BUILD_CACHE/$CHROOT_ARCHIVE_NAME"
 OUTPUT_DIRECTORY=~/build.output
@@ -117,6 +123,36 @@ LIVEFS_NAME="LOCAL_IMAGES_BUILD"
 SERIAL="$(date +%Y%m%d.%H%M)"
 
 mkdir -p $OLD_FASHIONED_BUILD_CACHE
+
+if [ $INTERACTIVE_HOOKS = true ] ; then
+    rm -rf $LIVECD_ROOTFS_COPY
+    cp -aR ./ $LIVECD_ROOTFS_COPY
+    cd $LIVECD_ROOTFS_COPY
+
+    cat > 001-debug.binary << "EOF"
+#!/bin/bash
+
+mknod debug.in p
+
+at_exit() {
+    rm -f debug.in
+}
+trap at_exit EXIT
+
+/bin/bash -x < debug.in 2>&1 &
+
+pid=$!
+
+while ps -p $pid >/dev/null 2>&1
+do
+    sleep 1
+done > debug.in
+EOF
+
+    rename 's/.binary$/.binary.disabled/' $(find live-build -name '*.binary')
+    find live-build -type d -name 'hooks' -exec cp 001-debug.binary {} \;
+    rm 001-debug.binary
+fi
 
 # Get the chroot filesystem from Launchpad if there isn't already one locally
 # we could reuse.


### PR DESCRIPTION
This will disable all hooks in livecd-rootfs, and replace them with a hook that opens a shell into the build process. You can inject commands into the process via a `debug.in` named pipe.

Live example: https://asciinema.org/a/q1VlNCFIT4fhrgb6PAisJ0PgZ