### PR TITLE
Extra quotes break ppa extras argument parsing at the livecd-rootfs level.

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -34,8 +34,8 @@ while :; do
             ;;
         --extra-ppa)
             # inject public ppas into the build environment
-            # e.g. 'lp:mylpname/someppa'
-            EXTRA_PPA="--extra-ppa \"$2\""
+            # e.g. 'mylpname/someppa'
+            EXTRA_PPA="--extra-ppa $2"
             shift
             ;;
         --image-format|--img_format)


### PR DESCRIPTION
There are two issues here. The first is the quoting around the ppa argument, which results in this command getting executed (note the quoting around the EXTRA_PPAS variable):

```
CalledProcessError: Command '['lxc', 'exec', 'lp-xenial-amd64', '--env', 'PROJECT=ubuntu-cpc', '--env', 'ARCH=amd64', '--env', 'IMAGE_TARGETS=ec2', '--env', 'SUITE=xenial', '--env', 'NOW=20190906.2041', '--env', 'IMAGEFORMAT=ext4', '--env', 'EXTRA_PPAS="cloud-images-release-managers/qemu-backports"', '--', '/bin/sh', '-c', 'cd /build && linux64 lb config']' returned non-zero exit status 1
```

That command ends with this failure (note the erroneous double quotes in the URL):

```
softwareproperties.ppa.PPAException: 'Error reading https://launchpad.net/api/1.0/~"cloud-images-release-managers/+archive/qemu-backports": Not Found'
```

The second issue is caused by this line in livecd-rootfs: [auto/config:953](https://git.launchpad.net/livecd-rootfs/tree/live-build/auto/config?h=ubuntu/xenial#n953). It will strip everything after a colon in the PPA name. So `lp:foo/bar` becomes just `lp`.

