### PR TITLE
We need the qemu-backports packages to build xenial images properly.

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -218,6 +218,14 @@ tar czvf $OLD_FASHIONED_BUILD_CACHE/live-build.tar.gz .
 lxc file push $OLD_FASHIONED_BUILD_CACHE/live-build.tar.gz lp-$SERIES-${ARCH}/usr/share/livecd-rootfs/
 lxc exec lp-$SERIES-${ARCH} -- tar xzvf /usr/share/livecd-rootfs/live-build.tar.gz -C /usr/share/livecd-rootfs/
 
+# Use qemu-backports to build xenial images. Otherwise, the images may not boot.
+if [ "$SERIES" = "xenial" ]; then
+  lxc exec lp-$SERIES-${ARCH} -- apt-get install -y software-properties-common
+  lxc exec lp-$SERIES-${ARCH} -- add-apt-repository -y ppa:cloud-images-release-managers/qemu-backports
+  lxc exec lp-$SERIES-${ARCH} -- apt-get update
+  lxc exec lp-$SERIES-${ARCH} -- apt-get install -y qemu-utils
+fi
+
 # Actually build.
 time /usr/share/launchpad-buildd/bin/in-target buildlivefs \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME $HTTP_PROXY \


### PR DESCRIPTION
When building Xenial images, we must install qemu-utils from a backports PPA. Otherwise, the images don't always boot.