### PR TITLE
Specify a local buildd chroot archive to build with

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -69,6 +69,12 @@ while :; do
             # been built
             USE_CHROOT_CACHE=true
             ;;
+        --use-chroot-archive)
+            # pass this flag to specify a chroot to use instead of the cache
+            USE_CHROOT_CACHE=true
+            CHROOT_ARCHIVE="$2"
+            shift
+            ;;
         --no-cleanup)
             # pass this flag to keep the lxd build environment after build has
             # finished or failed
@@ -145,7 +151,7 @@ set -xe
 OLD_FASHIONED_BUILD_CACHE="/tmp/old-fashioned-builder"
 UAT_CHECKOUT="$OLD_FASHIONED_BUILD_CACHE/uat"
 CHROOT_ARCHIVE_NAME="chroot-ubuntu-$SERIES-${ARCH}.tar.bz"
-CHROOT_ARCHIVE="$OLD_FASHIONED_BUILD_CACHE/$CHROOT_ARCHIVE_NAME"
+CHROOT_ARCHIVE="${CHROOT_ARCHIVE:-$OLD_FASHIONED_BUILD_CACHE/$CHROOT_ARCHIVE_NAME}"
 OUTPUT_DIRECTORY=~/build.output
 LIVEFS_NAME="LOCAL_IMAGES_BUILD"
 SERIAL="$(date +%Y%m%d.%H%M)"
@@ -184,7 +190,7 @@ if [ x"$SQUID_ADDRESS" != 'x' ] ; then
     cat > /tmp/30squid-proxy << EOF
 Acquire::http::Proxy "$SQUID_ADDRESS";
 EOF
-	lxc file push $SQUID_TMP_CONFIG lp-$SERIES-${ARCH}/etc/apt/apt.conf.d/30squid-proxy
+    lxc file push $SQUID_TMP_CONFIG lp-$SERIES-${ARCH}/etc/apt/apt.conf.d/30squid-proxy
 fi
 
 # Use the same apt mirror as the host

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -117,6 +117,9 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
     --hook-extras-dir <url>                 A local directory containing extra hooks.
                                             Value: ${HOOK_EXTRAS_DIR:-None}
 
+    --chroot-archive <archive>              A local archive used to perform the build.
+                                            Value: ${CHROOT_ARCHIVE:-None}
+
     --build-provider <provider>             The provider used to build the image.
                                             This can be either multipass or aws.
                                             Value: $BUILD_PROVIDER
@@ -167,6 +170,10 @@ do
       ;;
     --hook-extras-dir)
       HOOK_EXTRAS_DIR="$2"
+      shift
+      ;;
+    --chroot-archive)
+      CHROOT_ARCHIVE="$2"
       shift
       ;;
     --build-provider)
@@ -262,6 +269,12 @@ build-provider-create $bartender_name
     cp -aR "$LIVECD_ROOTFS_DIR" $temp_dir/livecd-rootfs
   fi
 
+  if [ -n "$CHROOT_ARCHIVE" ]
+  then
+    cp -aR "$CHROOT_ARCHIVE" $temp_dir/chroot-archive
+    chroot_archive_flag="--use-chroot-archive ../chroot-archive"
+  fi
+
   cd $temp_dir
 
   git clone -qb $UBUNTU_OLD_FASHIONED_BRANCH $UBUNTU_OLD_FASHIONED_REPO
@@ -293,7 +306,7 @@ sudo add-apt-repository -y -u ppa:launchpad/ppa
 sudo apt-get -q update
 sudo apt-get -q install -y launchpad-buildd bzr python-ubuntutools git
 cd livecd-rootfs
-sudo -E ../ubuntu-old-fashioned/old-fashioned-image-build --no-cleanup $series_flag $@
+sudo -E ../ubuntu-old-fashioned/old-fashioned-image-build --no-cleanup $chroot_archive_flag $series_flag $@
 EOF
 
   tar czf ingredients.tar.gz --exclude-vcs ./*


### PR DESCRIPTION
For example, you can now download a buildd rootfs tarball from
cloud-images [1] and use that environment to build images.

1: http://cloud-images.ubuntu.com/buildd/