### PR TITLE
Tools from ubuntu-archive repo have migrated to python3

### DIFF
--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -304,7 +304,7 @@ build-provider-create $bartender_name
 #!/bin/bash -x
 sudo add-apt-repository -y -u ppa:launchpad/ppa
 sudo apt-get -q update
-sudo apt-get -q install -y launchpad-buildd bzr python-ubuntutools git
+sudo apt-get -q install -y launchpad-buildd bzr python-ubuntutools git python3-ubuntutools python3-launchpadlib
 cd livecd-rootfs
 sudo -E ../ubuntu-old-fashioned/old-fashioned-image-build --no-cleanup $chroot_archive_flag $series_flag $@
 EOF


### PR DESCRIPTION
manage-chroot script from ubuntu-archive-to has migrated to python3 [1].
As such we need to install the python3 dependencies too.

[1] https://bazaar.launchpad.net/~ubuntu-archive/ubuntu-archive-tools/trunk/revision/1305