### PR TITLE
Cleanup the ubuntu-bartender script

### DIFF
--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -200,7 +200,7 @@ validate_old_fashioned_flags() {
 			 xargs -0I {} grep -o "${__flag_regex})" {} |
 			 tr -d ')'))
 
-	for flag in $(echo ${@} | grep -o "${__flag_regex}"); do
+	for flag in $(echo "${@}" | grep -o "${__flag_regex}"); do
 		if [[ ! "${valid_old_fashioned_flags[*]}" = *"${flag}"* ]]; then
 			echo -e "\nerror: unknown ubuntu-old-fashioned option '${flag}'\n" >&2
 			exit 255

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -2,6 +2,10 @@
 
 set -eo pipefail
 
+if [[ -n "${TRACE}" ]]; then
+	set -xv
+fi
+
 dependencies="petname git"
 
 for dependency in $dependencies

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -8,17 +8,6 @@ fi
 
 __flag_regex='\--[a-z-]\{1,\}'
 
-dependencies="petname git"
-
-for dependency in $dependencies
-do
-	if ! command -v $dependency &>/dev/null
-	then
-		echo "error: $dependency was not found in PATH" >&2
-		exit 255
-	fi
-done
-
 UBUNTU_OLD_FASHIONED_REPO=${UBUNTU_OLD_FASHIONED_REPO:-https://github.com/chrisglass/ubuntu-old-fashioned.git}
 LIVECD_ROOTFS_REPO=${LIVECD_ROOTFS_REPO:-https://git.launchpad.net/livecd-rootfs}
 HOOK_EXTRAS_REPO=${HOOK_EXTRAS_REPO:-}
@@ -115,6 +104,16 @@ Options specified after '--' separator are used by Ubuntu Old Fashioned directly
 EOF
 }
 
+assert_dependencies_installed() {
+	local dependencies=(petname git)
+	for dependency in "${dependencies[@]}"; do
+		if ! command -v "${dependency}" &>/dev/null; then
+			echo -e "\nerror: ${dependency} was not found in PATH\n" >&2
+			exit 255
+		fi
+	done
+}
+
 # Pull valid flags out of usage help text
 valid_flags=($(print_usage 2>&1 | grep -o "${__flag_regex}"))
 
@@ -156,6 +155,8 @@ then
 	print_usage
 	exit 255
 fi
+
+assert_dependencies_installed
 
 build_provider_config="$(dirname "$(readlink -f "$0")")/$BUILD_PROVIDER-provider"
 if [ ! -f "$build_provider_config" ]

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -259,6 +259,11 @@ build_images() {
 			--no-cleanup \
 			${@}
 	EOF
+
+	if [[ -n "${TRACE}" ]]; then
+		cat "${temp_dir}/mix-old-fashioned" >&2
+	fi
+
 	build-provider-upload "${bartender_name}" "${temp_dir}/mix-old-fashioned" "mix-old-fashioned"
 	build-provider-run "${bartender_name}" -- bash mix-old-fashioned &>"${bartender_name}.log" </dev/null
 

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -188,6 +188,63 @@ prepare_ingredients() {
 	)
 }
 
+build_images() {
+	local temp_dir
+	local bartender_name
+	local drink_name
+
+	temp_dir="$(mktemp --directory)"
+	bartender_name="$(petname)-ubuntu-bartender"
+	drink_name="${bartender_name/-bartender/-on-the-rocks.tar.gz}"
+
+	build-provider-assert-ready
+
+	cleanup() {
+		echo "Cleaning up..."
+		rm -rf "${temp_dir}"
+		build-provider-destroy "${bartender_name}"
+	}
+
+	if [[ "${SHOULD_CLEANUP}" = "YES" ]]; then
+		trap cleanup EXIT
+	fi
+
+	build-provider-create "${bartender_name}"
+
+	echo "Preparing ingredients..."
+	prepare_ingredients "${temp_dir}"
+	build-provider-upload "${bartender_name}" "${temp_dir}/ingredients.tar.gz" "ingredients.tar.gz"
+	build-provider-run "${bartender_name}" -- tar xf "ingredients.tar.gz"
+
+	echo "Mixing drink... (See progress in ${bartender_name}.log)"
+	cat > "${temp_dir}/mix-old-fashioned" <<- EOF
+		#!/bin/bash -x
+		sudo add-apt-repository -y -u ppa:launchpad/ppa
+		sleep 2
+		sudo apt-get -q update
+		sleep 2
+		sudo apt-get -q install -y \
+			launchpad-buildd \
+			python-ubuntutools \
+			python3-ubuntutools \
+			python3-launchpadlib \
+			bzr \
+			git
+		cd livecd-rootfs
+		sudo -E ../ubuntu-old-fashioned/old-fashioned-image-build \
+			${chroot_archive_flag[@]} \
+			${series_flag[@]} \
+			--no-cleanup \
+			${@}
+	EOF
+	build-provider-upload "${bartender_name}" "${temp_dir}/mix-old-fashioned" "mix-old-fashioned"
+	build-provider-run "${bartender_name}" -- bash mix-old-fashioned &>"${bartender_name}.log" </dev/null
+
+	echo "Pouring ${drink_name}..."
+	build-provider-run "${bartender_name}" -- tar czf "drink.tar.gz" "build.output"
+	build-provider-download "${bartender_name}" "drink.tar.gz" "${drink_name}"
+}
+
 assert_dependencies_installed
 
 apply_default_bartender_configuration
@@ -228,64 +285,19 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
-if [ "$SHOW_HELP" = "YES" ]
-then
+if [[ "${SHOW_HELP}" = "YES" ]]; then
 	print_usage
 	exit 255
 fi
 
 load_build_provider_configuration
 
-build-provider-assert-ready
-
-if [ -z "$series_flag" ] && ! echo -- $@ | grep -q -- --series
-then
-	echo "error: the '--series' option is required by ubuntu-old-fashioned" >&2
+# The --series flag is required by ubuntu-old-fashioned for image builds,
+# so we check to make sure we have it before moving on:
+if [[ -z "${series_flag[*]}" ]] && ! echo -- "${@}" | grep -q -- --series; then
+	echo -e "\nerror: the '--series' option is required by ubuntu-old-fashioned\n" >&2
 	print_usage
 	exit 255
 fi
 
-temp_dir=$(mktemp --directory)
-bartender_name=$(petname)-ubuntu-bartender
-drink_name=${bartender_name/-bartender/-on-the-rocks.tar.gz}
-
-function cleanup {
-	echo "Cleaning up..."
-	rm -rf $temp_dir
-	build-provider-destroy $bartender_name
-}
-
-if [ "$SHOULD_CLEANUP" = "YES" ]
-then
-	trap cleanup EXIT
-fi
-
-build-provider-create $bartender_name
-
-(
-	echo "Preparing ingredients..."
-	prepare_ingredients "${temp_dir}"
-
-	cd $temp_dir
-
-	build-provider-upload $bartender_name ingredients.tar.gz ingredients.tar.gz
-	build-provider-run $bartender_name -- tar xf ingredients.tar.gz
-
-	cat > mix-old-fashioned <<- EOF
-		#!/bin/bash -x
-		sudo add-apt-repository -y -u ppa:launchpad/ppa
-		sudo apt-get -q update
-		sudo apt-get -q install -y launchpad-buildd bzr python-ubuntutools git python3-ubuntutools python3-launchpadlib
-		cd livecd-rootfs
-		sudo -E ../ubuntu-old-fashioned/old-fashioned-image-build --no-cleanup $chroot_archive_flag $series_flag $@
-	EOF
-	build-provider-upload $bartender_name mix-old-fashioned mix-old-fashioned
-)
-
-echo "Mixing drink..."
-echo "(See progress in $bartender_name.log)"
-build-provider-run $bartender_name -- bash mix-old-fashioned &>$bartender_name.log </dev/null
-
-echo "Pouring $drink_name..."
-build-provider-run $bartender_name -- tar czf drink.tar.gz build.output
-build-provider-download $bartender_name drink.tar.gz $drink_name
+build_images "${@}"

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -126,6 +126,68 @@ load_build_provider_configuration() {
 	fi
 }
 
+prepare_livecd_rootfs() {
+	local staging_dir="${1}"
+
+	if [[ -n "${LIVECD_ROOTFS_DIR}" ]]; then
+		cp -aR "${LIVECD_ROOTFS_DIR}" "${staging_dir}/livecd-rootfs"
+	else
+		git clone -qb "${LIVECD_ROOTFS_BRANCH}" "${LIVECD_ROOTFS_REPO}" "${staging_dir}/livecd-rootfs"
+	fi
+}
+
+prepare_ubuntu_old_fashioned() {
+	local staging_dir="${1}"
+
+	if [[ -n "${UBUNTU_OLD_FASHIONED_DIR}" ]]; then
+		cp -aR "${UBUNTU_OLD_FASHIONED_DIR}" "${staging_dir}/ubuntu-old-fashioned"
+	else
+		git clone -qb "${UBUNTU_OLD_FASHIONED_BRANCH}" "${UBUNTU_OLD_FASHIONED_REPO}" "${staging_dir}/ubuntu-old-fashioned"
+	fi
+}
+
+prepare_extra_hooks() {
+	local staging_dir="${1}"
+
+	if [[ -n "${HOOK_EXTRAS_DIR}" ]]; then
+		cp -aR "${HOOK_EXTRAS_DIR}" "${staging_dir}/extras"
+	elif [[ -n "${HOOK_EXTRAS_REPO}" ]]; then
+		if [[ -n "${HOOK_EXTRAS_BRANCH}" ]]; then
+			local branch_flags=(-b "${HOOK_EXTRAS_BRANCH}")
+		fi
+		git clone -q "${branch_flags[@]}" "${HOOK_EXTRAS_REPO}" "${staging_dir}/extras"
+	fi
+
+	if [[ -d "${staging_dir}/extras" ]]; then
+		find "${staging_dir}/livecd-rootfs/live-build/" -type d -name '*hooks*' -print0 |
+			xargs -0I {} cp -af "${staging_dir}/extras/"* {}
+	fi
+}
+
+prepare_chroot_archive() {
+	local staging_dir="${1}"
+
+	if [[ -n "${CHROOT_ARCHIVE}" ]]; then
+		cp -aR "${CHROOT_ARCHIVE}" "${staging_dir}/chroot-archive"
+		# Set ubuntu-old-fashioned flag to use the chroot-archive
+		chroot_archive_flag=(--use-chroot-archive ../chroot-archive)
+	fi
+}
+
+prepare_ingredients() {
+	local staging_dir="${1}"
+
+	prepare_ubuntu_old_fashioned "${staging_dir}"
+	prepare_livecd_rootfs "${staging_dir}"
+	prepare_extra_hooks "${staging_dir}"
+	prepare_chroot_archive "${staging_dir}"
+
+	(
+		cd "${staging_dir}"
+		tar czf ingredients.tar.gz --exclude-vcs ./*
+	)
+}
+
 assert_dependencies_installed
 
 apply_default_bartender_configuration
@@ -202,55 +264,12 @@ build-provider-create $bartender_name
 
 (
 	echo "Preparing ingredients..."
-
-	if [ -n "$HOOK_EXTRAS_DIR" ]
-	then
-		cp -aR "$HOOK_EXTRAS_DIR" $temp_dir/extras
-	fi
-
-	if [ -n "$LIVECD_ROOTFS_DIR" ]
-	then
-		cp -aR "$LIVECD_ROOTFS_DIR" $temp_dir/livecd-rootfs
-	fi
-
-	if [ -n "$UBUNTU_OLD_FASHIONED_DIR" ]
-	then
-		cp -aR "$UBUNTU_OLD_FASHIONED_DIR" $temp_dir/ubuntu-old-fashioned
-	fi
-
-	if [ -n "$CHROOT_ARCHIVE" ]
-	then
-		cp -aR "$CHROOT_ARCHIVE" $temp_dir/chroot-archive
-		chroot_archive_flag="--use-chroot-archive ../chroot-archive"
-	fi
+	prepare_ingredients "${temp_dir}"
 
 	cd $temp_dir
 
-	if [ -z "$UBUNTU_OLD_FASHIONED_DIR" ]
-	then
-		git clone -qb $UBUNTU_OLD_FASHIONED_BRANCH $UBUNTU_OLD_FASHIONED_REPO
-	fi
-
-	if [ -z "$LIVECD_ROOTFS_DIR" ]
-	then
-		git clone -qb $LIVECD_ROOTFS_BRANCH $LIVECD_ROOTFS_REPO
-	fi
-
-	if [ -n "$HOOK_EXTRAS_REPO" ]
-	then
-		branch_flag=" "
-		if [ -n "$HOOK_EXTRAS_BRANCH" ]
-		then
-			branch_flag="-b $HOOK_EXTRAS_BRANCH"
-		fi
-		git clone -q $branch_flag $HOOK_EXTRAS_REPO extras
-	fi
-
-	if [ -d $temp_dir/extras ]
-	then
-		find livecd-rootfs/live-build/ -type d -name '*hooks*' |
-			xargs -I {} cp -af extras/* {}
-	fi
+	build-provider-upload $bartender_name ingredients.tar.gz ingredients.tar.gz
+	build-provider-run $bartender_name -- tar xf ingredients.tar.gz
 
 	cat > mix-old-fashioned <<- EOF
 		#!/bin/bash -x
@@ -260,10 +279,7 @@ build-provider-create $bartender_name
 		cd livecd-rootfs
 		sudo -E ../ubuntu-old-fashioned/old-fashioned-image-build --no-cleanup $chroot_archive_flag $series_flag $@
 	EOF
-
-	tar czf ingredients.tar.gz --exclude-vcs ./*
-	build-provider-upload $bartender_name ingredients.tar.gz ingredients.tar.gz
-	build-provider-run $bartender_name -- tar xf ingredients.tar.gz
+	build-provider-upload $bartender_name mix-old-fashioned mix-old-fashioned
 )
 
 echo "Mixing drink..."

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -eo pipefail
 
 dependencies="petname git"
 

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -188,6 +188,27 @@ prepare_ingredients() {
 	)
 }
 
+validate_old_fashioned_flags() {
+	local staging_dir="${1}"
+
+	# remaining arguments are flags for ubuntu-old-fashioned
+	shift
+
+	local valid_old_fashioned_flags
+	valid_old_fashioned_flags=(
+		$(find "${staging_dir}" -name 'old-fashioned-image-build' -print0 |
+			 xargs -0I {} grep -o "${__flag_regex})" {} |
+			 tr -d ')'))
+
+	for flag in $(echo ${@} | grep -o "${__flag_regex}"); do
+		if [[ ! "${valid_old_fashioned_flags[*]}" = *"${flag}"* ]]; then
+			echo -e "\nerror: unknown ubuntu-old-fashioned option '${flag}'\n" >&2
+			exit 255
+		fi
+		shift
+	done
+}
+
 build_images() {
 	local temp_dir
 	local bartender_name
@@ -213,6 +234,7 @@ build_images() {
 
 	echo "Preparing ingredients..."
 	prepare_ingredients "${temp_dir}"
+	validate_old_fashioned_flags "${temp_dir}" "${@}"
 	build-provider-upload "${bartender_name}" "${temp_dir}/ingredients.tar.gz" "ingredients.tar.gz"
 	build-provider-run "${bartender_name}" -- tar xf "ingredients.tar.gz"
 

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -1,44 +1,6 @@
 #!/bin/bash -e
 
-############ The Ubuntu Bartender #############################################
-
-# Sometimes you just want an Ubuntu Old Fashioned [1], but you don't want to
-# make it yourself.
-
-# Sometimes you just want someone else to gather the ingredients, make the
-# drink for you, and clean up afterwards.
-
-# So sit back, relax, and let the Ubuntu Bartender do the work for you.
-
-# 1: https://github.com/chrisglass/ubuntu-old-fashioned
-
-############ Overview #########################################################
-
-# This script will collect all the required bits Ubuntu Old Fashioned
-# needs to build Ubuntu images, build those images for you, then clean up
-# afterwards.
-
-# A simple bionic build can be accomplished with the incantation:
-
-# ./ubuntu-bartender --livecd-rootfs-branch ubuntu/bionic -- --series bionic
-
-# Arguments specified after the -- are used by Ubuntu Old Fashioned directly.
-
-# The Ubuntu Bartender can also be invoked with series specific helper script
-# that can save you from needing to manually specify the correct livecd_rootfs
-# branch and series.
-
-# For example, this is identical to the invocation above:
-
-# ./ubuntu-bionic-bartender
-
-############ Dependencies #####################################################
-
-# The Ubuntu Bartender requires the following executables to be in the PATH:
-
 dependencies="petname git"
-
-# Which we verify before moving on:
 
 for dependency in $dependencies
 do
@@ -49,32 +11,17 @@ do
   fi
 done
 
-############ Configuration ####################################################
-
-# The Ubuntu Bartender needs to know the location of a few git repositories:
-
 UBUNTU_OLD_FASHIONED_REPO=${UBUNTU_OLD_FASHIONED_REPO:-https://github.com/chrisglass/ubuntu-old-fashioned.git}
 LIVECD_ROOTFS_REPO=${LIVECD_ROOTFS_REPO:-https://git.launchpad.net/livecd-rootfs}
 HOOK_EXTRAS_REPO=${HOOK_EXTRAS_REPO:-}
 HOOK_EXTRAS_DIR=${HOOK_EXTRAS_DIR:-}
 
-# And any specific branches for each that should be used:
-
 UBUNTU_OLD_FASHIONED_BRANCH=${UBUNTU_OLD_FASHIONED_BRANCH:-master}
-# LIVECD_ROOTFS_BRANCH is inferred below from the script name
 HOOK_EXTRAS_BRANCH=${HOOK_EXTRAS_BRANCH:-}
-
-# The Ubuntu Bartender utilizes a build-provider to create Ubuntu Images.
-# We use multipass by default:
 
 BUILD_PROVIDER=${BUILD_PROVIDER:-multipass}
 
-# Should we tear down the build provider and clean up after ourselves
-# when the build is completed?
-
 SHOULD_CLEANUP=${SHOULD_CLEANUP:-YES}
-
-# Parse the name of the script to see if we can infer some variables
 
 maybe_series=$(basename $0 | cut -d'-' -f2)
 if [ "$maybe_series" != "bartender" ]
@@ -85,8 +32,6 @@ else
   series_flag=""
   LIVECD_ROOTFS_BRANCH=${LIVECD_ROOTFS_BRANCH:-ubuntu/master}
 fi
-
-# We also pull in explicitly set variables on the command line
 
 function print-usage {
   cat << EOF >&2
@@ -136,8 +81,6 @@ Options specified after '--' separator are used by Ubuntu Old Fashioned directly
 
 EOF
 }
-
-# Which we parse with the typical boilerplate:
 
 while [[ $# -gt 0 ]]
 do
@@ -217,8 +160,6 @@ then
   exit 255
 fi
 
-# Verify that the specified build provider is available and ready
-
 build_provider_config="$(dirname "$(readlink -f "$0")")/$BUILD_PROVIDER-provider"
 if [ ! -f "$build_provider_config" ]
 then
@@ -231,19 +172,12 @@ source "$build_provider_config"
 
 build-provider-assert-ready
 
-# The --series flag is required by ubuntu-old-fashioned for image builds,
-# so we check to make sure we have it before moving on:
-
 if [ -z "$series_flag" ] && ! echo -- $@ | grep -q -- --series
 then
   echo "error: the '--series' option is required by ubuntu-old-fashioned" >&2
   print-usage
   exit 255
 fi
-
-############ Where the Magic Happens ##########################################
-
-# Let's build all the things!
 
 temp_dir=$(mktemp --directory)
 bartender_name=$(petname)-ubuntu-bartender

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -6,29 +6,10 @@ if [[ -n "${TRACE}" ]]; then
 	set -xv
 fi
 
+__bartender_cmd_name="$(basename "${0}")"
+__bartender_cmd_dir="$(dirname "$(readlink -f "${0}")")"
+
 __flag_regex='\--[a-z-]\{1,\}'
-
-UBUNTU_OLD_FASHIONED_REPO=${UBUNTU_OLD_FASHIONED_REPO:-https://github.com/chrisglass/ubuntu-old-fashioned.git}
-LIVECD_ROOTFS_REPO=${LIVECD_ROOTFS_REPO:-https://git.launchpad.net/livecd-rootfs}
-HOOK_EXTRAS_REPO=${HOOK_EXTRAS_REPO:-}
-HOOK_EXTRAS_DIR=${HOOK_EXTRAS_DIR:-}
-
-UBUNTU_OLD_FASHIONED_BRANCH=${UBUNTU_OLD_FASHIONED_BRANCH:-master}
-HOOK_EXTRAS_BRANCH=${HOOK_EXTRAS_BRANCH:-}
-
-BUILD_PROVIDER=${BUILD_PROVIDER:-multipass}
-
-SHOULD_CLEANUP=${SHOULD_CLEANUP:-YES}
-
-maybe_series=$(basename $0 | cut -d'-' -f2)
-if [ "$maybe_series" != "bartender" ]
-then
-	series_flag="--series $maybe_series"
-	LIVECD_ROOTFS_BRANCH=${LIVECD_ROOTFS_BRANCH:-ubuntu/$maybe_series}
-else
-	series_flag=""
-	LIVECD_ROOTFS_BRANCH=${LIVECD_ROOTFS_BRANCH:-ubuntu/master}
-fi
 
 print_usage() {
 	cat << EOF >&2
@@ -104,6 +85,24 @@ Options specified after '--' separator are used by Ubuntu Old Fashioned directly
 EOF
 }
 
+apply_default_bartender_configuration() {
+	BUILD_PROVIDER=${BUILD_PROVIDER:-multipass}
+	SHOULD_CLEANUP=${SHOULD_CLEANUP:-YES}
+	LIVECD_ROOTFS_REPO=${LIVECD_ROOTFS_REPO:-https://git.launchpad.net/livecd-rootfs}
+	UBUNTU_OLD_FASHIONED_REPO=${UBUNTU_OLD_FASHIONED_REPO:-https://github.com/chrisglass/ubuntu-old-fashioned.git}
+	UBUNTU_OLD_FASHIONED_BRANCH=${UBUNTU_OLD_FASHIONED_BRANCH:-master}
+
+	# Infer series configuration from script name
+	local maybe_series
+	maybe_series=$(echo "${__bartender_cmd_name}" | cut -d'-' -f2)
+	if [[ "${maybe_series}" != "bartender" ]]; then
+		LIVECD_ROOTFS_BRANCH=${LIVECD_ROOTFS_BRANCH:-ubuntu/${maybe_series}}
+		series_flag=(--series ${maybe_series})
+	else
+		LIVECD_ROOTFS_BRANCH=${LIVECD_ROOTFS_BRANCH:-ubuntu/master}
+	fi
+}
+
 assert_dependencies_installed() {
 	local dependencies=(petname git)
 	for dependency in "${dependencies[@]}"; do
@@ -157,6 +156,8 @@ then
 fi
 
 assert_dependencies_installed
+
+apply_default_bartender_configuration
 
 build_provider_config="$(dirname "$(readlink -f "$0")")/$BUILD_PROVIDER-provider"
 if [ ! -f "$build_provider_config" ]

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -6,6 +6,8 @@ if [[ -n "${TRACE}" ]]; then
 	set -xv
 fi
 
+__flag_regex='\--[a-z-]\{1,\}'
+
 dependencies="petname git"
 
 for dependency in $dependencies
@@ -113,77 +115,41 @@ Options specified after '--' separator are used by Ubuntu Old Fashioned directly
 EOF
 }
 
-while [[ $# -gt 0 ]]
-do
-	case $1 in
-		--livecd-rootfs-repo)
-			LIVECD_ROOTFS_REPO="$2"
-			shift
-			;;
-		--livecd-rootfs-branch)
-			LIVECD_ROOTFS_BRANCH="$2"
-			shift
-			;;
-		--livecd-rootfs-dir)
-			LIVECD_ROOTFS_DIR="$2"
-			shift
-			;;
-		--ubuntu-old-fashioned-repo)
-			UBUNTU_OLD_FASHIONED_REPO="$2"
-			shift
-			;;
-		--ubuntu-old-fashioned-branch)
-			UBUNTU_OLD_FASHIONED_BRANCH="$2"
-			shift
-			;;
-		--ubuntu-old-fashioned-dir)
-			UBUNTU_OLD_FASHIONED_DIR="$2"
-			shift
-			;;
-		--hook-extras-repo)
-			HOOK_EXTRAS_REPO="$2"
-			shift
-			;;
-		--hook-extras-branch)
-			HOOK_EXTRAS_BRANCH="$2"
-			shift
-			;;
-		--hook-extras-dir)
-			HOOK_EXTRAS_DIR="$2"
-			shift
-			;;
-		--chroot-archive)
-			CHROOT_ARCHIVE="$2"
-			shift
-			;;
-		--build-provider)
-			BUILD_PROVIDER="$2"
-			shift
-			;;
-		--no-cleanup)
-			SHOULD_CLEANUP=NO
-			;;
-		--)
-			shift
-			break
-			;;
-		--help)
-			SHOW_HELP=YES
-			;;
-		*)
-			echo "error: unknown option '$1'" >&2
-			exit 255
-			;;
-	esac
-	shift
-done
+# Pull valid flags out of usage help text
+valid_flags=($(print_usage 2>&1 | grep -o "${__flag_regex}"))
 
-if [ -n "$HOOK_EXTRAS_REPO" ] && [ -n "$HOOK_EXTRAS_DIR" ]
-then
-	echo "error: cannot specify both --hook-extras-repo and --hook-extras-dir" >&2
-	print_usage
-	exit 255
-fi
+# Parse command line flags
+while [[ $# -gt 0 ]]; do
+	case ${1} in
+	--help)
+		SHOW_HELP=YES
+		shift
+		;;
+	--no-cleanup)
+		SHOULD_CLEANUP=NO
+		shift
+		;;
+	--)
+		shift
+		break
+		;;
+	--*)
+		if [[ "${valid_flags[*]}" = *"${1}"* ]]; then
+			VAR=$(echo "${1}" | cut -d- -f3- | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+			declare "${VAR}"="${2}"
+			shift
+			shift
+			continue
+		fi
+		# If the flag is invalid, drop-through to error handling
+		;&
+	*)
+		echo -e "\nerror: unknown option '${1}'\n" >&2
+		print_usage
+		exit 255
+		;;
+	esac
+done
 
 if [ "$SHOW_HELP" = "YES" ]
 then

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -4,11 +4,11 @@ dependencies="petname git"
 
 for dependency in $dependencies
 do
-  if ! command -v $dependency &>/dev/null
-  then
-    echo "error: $dependency was not found in PATH" >&2
-    exit 255
-  fi
+	if ! command -v $dependency &>/dev/null
+	then
+		echo "error: $dependency was not found in PATH" >&2
+		exit 255
+	fi
 done
 
 UBUNTU_OLD_FASHIONED_REPO=${UBUNTU_OLD_FASHIONED_REPO:-https://github.com/chrisglass/ubuntu-old-fashioned.git}
@@ -26,56 +26,56 @@ SHOULD_CLEANUP=${SHOULD_CLEANUP:-YES}
 maybe_series=$(basename $0 | cut -d'-' -f2)
 if [ "$maybe_series" != "bartender" ]
 then
-  series_flag="--series $maybe_series"
-  LIVECD_ROOTFS_BRANCH=${LIVECD_ROOTFS_BRANCH:-ubuntu/$maybe_series}
+	series_flag="--series $maybe_series"
+	LIVECD_ROOTFS_BRANCH=${LIVECD_ROOTFS_BRANCH:-ubuntu/$maybe_series}
 else
-  series_flag=""
-  LIVECD_ROOTFS_BRANCH=${LIVECD_ROOTFS_BRANCH:-ubuntu/master}
+	series_flag=""
+	LIVECD_ROOTFS_BRANCH=${LIVECD_ROOTFS_BRANCH:-ubuntu/master}
 fi
 
 function print-usage {
-  cat << EOF >&2
+	cat << EOF >&2
 usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
 
-    --livecd-rootfs-repo <url>              The url to the git repo hosting livecd-rootfs.
-                                            Value: $LIVECD_ROOTFS_REPO
+		--livecd-rootfs-repo <url>							The url to the git repo hosting livecd-rootfs.
+																						Value: $LIVECD_ROOTFS_REPO
 
-    --livecd-rootfs-branch <branch>         The branch of livecd-rootfs to use.
-                                            Value: $LIVECD_ROOTFS_BRANCH
+		--livecd-rootfs-branch <branch>				 The branch of livecd-rootfs to use.
+																						Value: $LIVECD_ROOTFS_BRANCH
 
-    --livecd-rootfs-dir <dir>               A local directory containing livecd-rootfs.
-                                            Value: ${LIVECD_ROOTFS_DIR:-None}
+		--livecd-rootfs-dir <dir>							 A local directory containing livecd-rootfs.
+																						Value: ${LIVECD_ROOTFS_DIR:-None}
 
-    --ubuntu-old-fashioned-repo <url>       The url to the git repo hosting ubuntu-old-fashioned.
-                                            Value: $UBUNTU_OLD_FASHIONED_REPO
+		--ubuntu-old-fashioned-repo <url>			 The url to the git repo hosting ubuntu-old-fashioned.
+																						Value: $UBUNTU_OLD_FASHIONED_REPO
 
-    --ubuntu-old-fashioned-branch <branch>  The branch of ubuntu-old-fashioned to use.
-                                            Value: $UBUNTU_OLD_FASHIONED_BRANCH
+		--ubuntu-old-fashioned-branch <branch>	The branch of ubuntu-old-fashioned to use.
+																						Value: $UBUNTU_OLD_FASHIONED_BRANCH
 
-    --ubuntu-old-fashioned-dir <dir>        A local directory containing ubuntu-old-fashioned.
-                                            Value: ${UBUNTU_OLD_FASHIONED_DIR:-None}
+		--ubuntu-old-fashioned-dir <dir>				A local directory containing ubuntu-old-fashioned.
+																						Value: ${UBUNTU_OLD_FASHIONED_DIR:-None}
 
-    --hook-extras-repo <url>                The url to a git repo hosting extra hooks.
-                                            Value: ${HOOK_EXTRAS_REPO:-None}
+		--hook-extras-repo <url>								The url to a git repo hosting extra hooks.
+																						Value: ${HOOK_EXTRAS_REPO:-None}
 
-    --hook-extras-branch <branch>           The branch of the extras-repo to use.
-                                            Value: ${HOOK_EXTRAS_BRANCH:-None}
+		--hook-extras-branch <branch>					 The branch of the extras-repo to use.
+																						Value: ${HOOK_EXTRAS_BRANCH:-None}
 
-    --hook-extras-dir <dir>                 A local directory containing extra hooks.
-                                            Value: ${HOOK_EXTRAS_DIR:-None}
+		--hook-extras-dir <dir>								 A local directory containing extra hooks.
+																						Value: ${HOOK_EXTRAS_DIR:-None}
 
-    --chroot-archive <archive>              A local archive used to perform the build.
-                                            Value: ${CHROOT_ARCHIVE:-None}
+		--chroot-archive <archive>							A local archive used to perform the build.
+																						Value: ${CHROOT_ARCHIVE:-None}
 
-    --build-provider <provider>             The provider used to build the image.
-                                            This can be either multipass or aws.
-                                            Value: $BUILD_PROVIDER
+		--build-provider <provider>						 The provider used to build the image.
+																						This can be either multipass or aws.
+																						Value: $BUILD_PROVIDER
 
-    --no-cleanup                            Don't tear down the build provider
-                                            after the build completes.
-                                            Value: Cleanup? $SHOULD_CLEANUP
+		--no-cleanup														Don't tear down the build provider
+																						after the build completes.
+																						Value: Cleanup? $SHOULD_CLEANUP
 
-    --help                                  Print this help message.
+		--help																	Print this help message.
 
 Options specified after '--' separator are used by Ubuntu Old Fashioned directly.
 
@@ -84,88 +84,88 @@ EOF
 
 while [[ $# -gt 0 ]]
 do
-  case $1 in
-    --livecd-rootfs-repo)
-      LIVECD_ROOTFS_REPO="$2"
-      shift
-      ;;
-    --livecd-rootfs-branch)
-      LIVECD_ROOTFS_BRANCH="$2"
-      shift
-      ;;
-    --livecd-rootfs-dir)
-      LIVECD_ROOTFS_DIR="$2"
-      shift
-      ;;
-    --ubuntu-old-fashioned-repo)
-      UBUNTU_OLD_FASHIONED_REPO="$2"
-      shift
-      ;;
-    --ubuntu-old-fashioned-branch)
-      UBUNTU_OLD_FASHIONED_BRANCH="$2"
-      shift
-      ;;
-    --ubuntu-old-fashioned-dir)
-      UBUNTU_OLD_FASHIONED_DIR="$2"
-      shift
-      ;;
-    --hook-extras-repo)
-      HOOK_EXTRAS_REPO="$2"
-      shift
-      ;;
-    --hook-extras-branch)
-      HOOK_EXTRAS_BRANCH="$2"
-      shift
-      ;;
-    --hook-extras-dir)
-      HOOK_EXTRAS_DIR="$2"
-      shift
-      ;;
-    --chroot-archive)
-      CHROOT_ARCHIVE="$2"
-      shift
-      ;;
-    --build-provider)
-      BUILD_PROVIDER="$2"
-      shift
-      ;;
-    --no-cleanup)
-      SHOULD_CLEANUP=NO
-      ;;
-    --)
-      shift
-      break
-      ;;
-    --help)
-      SHOW_HELP=YES
-      ;;
-    *)
-      echo "error: unknown option '$1'" >&2
-      exit 255
-      ;;
-  esac
-  shift
+	case $1 in
+		--livecd-rootfs-repo)
+			LIVECD_ROOTFS_REPO="$2"
+			shift
+			;;
+		--livecd-rootfs-branch)
+			LIVECD_ROOTFS_BRANCH="$2"
+			shift
+			;;
+		--livecd-rootfs-dir)
+			LIVECD_ROOTFS_DIR="$2"
+			shift
+			;;
+		--ubuntu-old-fashioned-repo)
+			UBUNTU_OLD_FASHIONED_REPO="$2"
+			shift
+			;;
+		--ubuntu-old-fashioned-branch)
+			UBUNTU_OLD_FASHIONED_BRANCH="$2"
+			shift
+			;;
+		--ubuntu-old-fashioned-dir)
+			UBUNTU_OLD_FASHIONED_DIR="$2"
+			shift
+			;;
+		--hook-extras-repo)
+			HOOK_EXTRAS_REPO="$2"
+			shift
+			;;
+		--hook-extras-branch)
+			HOOK_EXTRAS_BRANCH="$2"
+			shift
+			;;
+		--hook-extras-dir)
+			HOOK_EXTRAS_DIR="$2"
+			shift
+			;;
+		--chroot-archive)
+			CHROOT_ARCHIVE="$2"
+			shift
+			;;
+		--build-provider)
+			BUILD_PROVIDER="$2"
+			shift
+			;;
+		--no-cleanup)
+			SHOULD_CLEANUP=NO
+			;;
+		--)
+			shift
+			break
+			;;
+		--help)
+			SHOW_HELP=YES
+			;;
+		*)
+			echo "error: unknown option '$1'" >&2
+			exit 255
+			;;
+	esac
+	shift
 done
 
 if [ -n "$HOOK_EXTRAS_REPO" ] && [ -n "$HOOK_EXTRAS_DIR" ]
 then
-  echo "error: cannot specify both --hook-extras-repo and --hook-extras-dir" >&2
-  print-usage
-  exit 255
+	echo "error: cannot specify both --hook-extras-repo and --hook-extras-dir" >&2
+	print-usage
+	exit 255
 fi
 
 if [ "$SHOW_HELP" = "YES" ]
 then
-  print-usage
-  exit 255
+	print-usage
+	exit 255
 fi
 
 build_provider_config="$(dirname "$(readlink -f "$0")")/$BUILD_PROVIDER-provider"
 if [ ! -f "$build_provider_config" ]
 then
-  echo "error: invalid build provider specified: $BUILD_PROVIDER" >&2
-  print-usage
-  exit 255
+	echo "error: invalid build provider specified: $BUILD_PROVIDER" >&2
+	print-usage
+	exit 255
 fi
 
 source "$build_provider_config"
@@ -174,9 +174,9 @@ build-provider-assert-ready
 
 if [ -z "$series_flag" ] && ! echo -- $@ | grep -q -- --series
 then
-  echo "error: the '--series' option is required by ubuntu-old-fashioned" >&2
-  print-usage
-  exit 255
+	echo "error: the '--series' option is required by ubuntu-old-fashioned" >&2
+	print-usage
+	exit 255
 fi
 
 temp_dir=$(mktemp --directory)
@@ -184,82 +184,82 @@ bartender_name=$(petname)-ubuntu-bartender
 drink_name=${bartender_name/-bartender/-on-the-rocks.tar.gz}
 
 function cleanup {
-  echo "Cleaning up..."
-  rm -rf $temp_dir
-  build-provider-destroy $bartender_name
+	echo "Cleaning up..."
+	rm -rf $temp_dir
+	build-provider-destroy $bartender_name
 }
 
 if [ "$SHOULD_CLEANUP" = "YES" ]
 then
-  trap cleanup EXIT
+	trap cleanup EXIT
 fi
 
 build-provider-create $bartender_name
 
 (
-  echo "Preparing ingredients..."
+	echo "Preparing ingredients..."
 
-  if [ -n "$HOOK_EXTRAS_DIR" ]
-  then
-    cp -aR "$HOOK_EXTRAS_DIR" $temp_dir/extras
-  fi
+	if [ -n "$HOOK_EXTRAS_DIR" ]
+	then
+		cp -aR "$HOOK_EXTRAS_DIR" $temp_dir/extras
+	fi
 
-  if [ -n "$LIVECD_ROOTFS_DIR" ]
-  then
-    cp -aR "$LIVECD_ROOTFS_DIR" $temp_dir/livecd-rootfs
-  fi
+	if [ -n "$LIVECD_ROOTFS_DIR" ]
+	then
+		cp -aR "$LIVECD_ROOTFS_DIR" $temp_dir/livecd-rootfs
+	fi
 
-  if [ -n "$UBUNTU_OLD_FASHIONED_DIR" ]
-  then
-    cp -aR "$UBUNTU_OLD_FASHIONED_DIR" $temp_dir/ubuntu-old-fashioned
-  fi
+	if [ -n "$UBUNTU_OLD_FASHIONED_DIR" ]
+	then
+		cp -aR "$UBUNTU_OLD_FASHIONED_DIR" $temp_dir/ubuntu-old-fashioned
+	fi
 
-  if [ -n "$CHROOT_ARCHIVE" ]
-  then
-    cp -aR "$CHROOT_ARCHIVE" $temp_dir/chroot-archive
-    chroot_archive_flag="--use-chroot-archive ../chroot-archive"
-  fi
+	if [ -n "$CHROOT_ARCHIVE" ]
+	then
+		cp -aR "$CHROOT_ARCHIVE" $temp_dir/chroot-archive
+		chroot_archive_flag="--use-chroot-archive ../chroot-archive"
+	fi
 
-  cd $temp_dir
+	cd $temp_dir
 
-  if [ -z "$UBUNTU_OLD_FASHIONED_DIR" ]
-  then
-    git clone -qb $UBUNTU_OLD_FASHIONED_BRANCH $UBUNTU_OLD_FASHIONED_REPO
-  fi
+	if [ -z "$UBUNTU_OLD_FASHIONED_DIR" ]
+	then
+		git clone -qb $UBUNTU_OLD_FASHIONED_BRANCH $UBUNTU_OLD_FASHIONED_REPO
+	fi
 
-  if [ -z "$LIVECD_ROOTFS_DIR" ]
-  then
-    git clone -qb $LIVECD_ROOTFS_BRANCH $LIVECD_ROOTFS_REPO
-  fi
+	if [ -z "$LIVECD_ROOTFS_DIR" ]
+	then
+		git clone -qb $LIVECD_ROOTFS_BRANCH $LIVECD_ROOTFS_REPO
+	fi
 
-  if [ -n "$HOOK_EXTRAS_REPO" ]
-  then
-    branch_flag=" "
-    if [ -n "$HOOK_EXTRAS_BRANCH" ]
-    then
-      branch_flag="-b $HOOK_EXTRAS_BRANCH"
-    fi
-    git clone -q $branch_flag $HOOK_EXTRAS_REPO extras
-  fi
+	if [ -n "$HOOK_EXTRAS_REPO" ]
+	then
+		branch_flag=" "
+		if [ -n "$HOOK_EXTRAS_BRANCH" ]
+		then
+			branch_flag="-b $HOOK_EXTRAS_BRANCH"
+		fi
+		git clone -q $branch_flag $HOOK_EXTRAS_REPO extras
+	fi
 
-  if [ -d $temp_dir/extras ]
-  then
-    find livecd-rootfs/live-build/ -type d -name '*hooks*' |
-      xargs -I {} cp -af extras/* {}
-  fi
+	if [ -d $temp_dir/extras ]
+	then
+		find livecd-rootfs/live-build/ -type d -name '*hooks*' |
+			xargs -I {} cp -af extras/* {}
+	fi
 
-  cat > mix-old-fashioned << EOF
-#!/bin/bash -x
-sudo add-apt-repository -y -u ppa:launchpad/ppa
-sudo apt-get -q update
-sudo apt-get -q install -y launchpad-buildd bzr python-ubuntutools git python3-ubuntutools python3-launchpadlib
-cd livecd-rootfs
-sudo -E ../ubuntu-old-fashioned/old-fashioned-image-build --no-cleanup $chroot_archive_flag $series_flag $@
-EOF
+	cat > mix-old-fashioned <<- EOF
+		#!/bin/bash -x
+		sudo add-apt-repository -y -u ppa:launchpad/ppa
+		sudo apt-get -q update
+		sudo apt-get -q install -y launchpad-buildd bzr python-ubuntutools git python3-ubuntutools python3-launchpadlib
+		cd livecd-rootfs
+		sudo -E ../ubuntu-old-fashioned/old-fashioned-image-build --no-cleanup $chroot_archive_flag $series_flag $@
+	EOF
 
-  tar czf ingredients.tar.gz --exclude-vcs ./*
-  build-provider-upload $bartender_name ingredients.tar.gz ingredients.tar.gz
-  build-provider-run $bartender_name -- tar xf ingredients.tar.gz
+	tar czf ingredients.tar.gz --exclude-vcs ./*
+	build-provider-upload $bartender_name ingredients.tar.gz ingredients.tar.gz
+	build-provider-run $bartender_name -- tar xf ingredients.tar.gz
 )
 
 echo "Mixing drink..."

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -113,6 +113,23 @@ assert_dependencies_installed() {
 	done
 }
 
+load_build_provider_configuration() {
+	local build_provider_config="${__bartender_cmd_dir}/${BUILD_PROVIDER}-provider"
+	if [[ -f "${build_provider_config}" ]]; then
+		# Ignore shellcheck warnings when trying to scan this file
+		# shellcheck source=/dev/null
+		source "${build_provider_config}"
+	else
+		echo -e "\nerror: invalid build provider specified: ${BUILD_PROVIDER}\n" >&2
+		print_usage
+		exit 255
+	fi
+}
+
+assert_dependencies_installed
+
+apply_default_bartender_configuration
+
 # Pull valid flags out of usage help text
 valid_flags=($(print_usage 2>&1 | grep -o "${__flag_regex}"))
 
@@ -155,19 +172,7 @@ then
 	exit 255
 fi
 
-assert_dependencies_installed
-
-apply_default_bartender_configuration
-
-build_provider_config="$(dirname "$(readlink -f "$0")")/$BUILD_PROVIDER-provider"
-if [ ! -f "$build_provider_config" ]
-then
-	echo "error: invalid build provider specified: $BUILD_PROVIDER" >&2
-	print_usage
-	exit 255
-fi
-
-source "$build_provider_config"
+load_build_provider_configuration
 
 build-provider-assert-ready
 

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -39,49 +39,74 @@ else
 	LIVECD_ROOTFS_BRANCH=${LIVECD_ROOTFS_BRANCH:-ubuntu/master}
 fi
 
-function print-usage {
+print_usage() {
 	cat << EOF >&2
-usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
+usage: ${0} [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
 
-		--livecd-rootfs-repo <url>							The url to the git repo hosting livecd-rootfs.
-																						Value: $LIVECD_ROOTFS_REPO
+	--livecd-rootfs-repo <url>
 
-		--livecd-rootfs-branch <branch>				 The branch of livecd-rootfs to use.
-																						Value: $LIVECD_ROOTFS_BRANCH
+		The url to the git repo hosting livecd-rootfs.
+		Value: ${LIVECD_ROOTFS_REPO}
 
-		--livecd-rootfs-dir <dir>							 A local directory containing livecd-rootfs.
-																						Value: ${LIVECD_ROOTFS_DIR:-None}
+	--livecd-rootfs-branch <branch>
 
-		--ubuntu-old-fashioned-repo <url>			 The url to the git repo hosting ubuntu-old-fashioned.
-																						Value: $UBUNTU_OLD_FASHIONED_REPO
+		The branch of livecd-rootfs to use.
+		Value: ${LIVECD_ROOTFS_BRANCH}
 
-		--ubuntu-old-fashioned-branch <branch>	The branch of ubuntu-old-fashioned to use.
-																						Value: $UBUNTU_OLD_FASHIONED_BRANCH
+	--livecd-rootfs-dir <dir>
 
-		--ubuntu-old-fashioned-dir <dir>				A local directory containing ubuntu-old-fashioned.
-																						Value: ${UBUNTU_OLD_FASHIONED_DIR:-None}
+		A local directory containing livecd-rootfs.
+		Value: ${LIVECD_ROOTFS_DIR:-None}
 
-		--hook-extras-repo <url>								The url to a git repo hosting extra hooks.
-																						Value: ${HOOK_EXTRAS_REPO:-None}
+	--ubuntu-old-fashioned-repo <url>
 
-		--hook-extras-branch <branch>					 The branch of the extras-repo to use.
-																						Value: ${HOOK_EXTRAS_BRANCH:-None}
+		The url to the git repo hosting ubuntu-old-fashioned.
+		Value: ${UBUNTU_OLD_FASHIONED_REPO}
 
-		--hook-extras-dir <dir>								 A local directory containing extra hooks.
-																						Value: ${HOOK_EXTRAS_DIR:-None}
+	--ubuntu-old-fashioned-branch <branch>
 
-		--chroot-archive <archive>							A local archive used to perform the build.
-																						Value: ${CHROOT_ARCHIVE:-None}
+		The branch of ubuntu-old-fashioned to use.
+		Value: ${UBUNTU_OLD_FASHIONED_BRANCH}
 
-		--build-provider <provider>						 The provider used to build the image.
-																						This can be either multipass or aws.
-																						Value: $BUILD_PROVIDER
+	--ubuntu-old-fashioned-dir <dir>
 
-		--no-cleanup														Don't tear down the build provider
-																						after the build completes.
-																						Value: Cleanup? $SHOULD_CLEANUP
+		A local directory containing ubuntu-old-fashioned.
+		Value: ${UBUNTU_OLD_FASHIONED_DIR:-None}
 
-		--help																	Print this help message.
+	--hook-extras-repo <url>
+
+		The url to a git repo hosting extra hooks.
+		Value: ${HOOK_EXTRAS_REPO:-None}
+
+	--hook-extras-branch <branch>
+
+		The branch of the extras-repo to use.
+		Value: ${HOOK_EXTRAS_BRANCH:-None}
+
+	--hook-extras-dir <dir>
+
+		A local directory containing extra hooks.
+		Value: ${HOOK_EXTRAS_DIR:-None}
+
+	--chroot-archive <archive>
+
+		A local archive used to perform the build.
+		Value: ${CHROOT_ARCHIVE:-None}
+
+	--build-provider <provider>
+
+		The provider used to build the image.
+		This can be either multipass or aws.
+		Value: ${BUILD_PROVIDER}
+
+	--no-cleanup
+
+		Don't tear down the build provider after the build completes.
+		Value: Cleanup? ${SHOULD_CLEANUP}
+
+	--help
+
+		Print this help message.
 
 Options specified after '--' separator are used by Ubuntu Old Fashioned directly.
 
@@ -156,13 +181,13 @@ done
 if [ -n "$HOOK_EXTRAS_REPO" ] && [ -n "$HOOK_EXTRAS_DIR" ]
 then
 	echo "error: cannot specify both --hook-extras-repo and --hook-extras-dir" >&2
-	print-usage
+	print_usage
 	exit 255
 fi
 
 if [ "$SHOW_HELP" = "YES" ]
 then
-	print-usage
+	print_usage
 	exit 255
 fi
 
@@ -170,7 +195,7 @@ build_provider_config="$(dirname "$(readlink -f "$0")")/$BUILD_PROVIDER-provider
 if [ ! -f "$build_provider_config" ]
 then
 	echo "error: invalid build provider specified: $BUILD_PROVIDER" >&2
-	print-usage
+	print_usage
 	exit 255
 fi
 
@@ -181,7 +206,7 @@ build-provider-assert-ready
 if [ -z "$series_flag" ] && ! echo -- $@ | grep -q -- --series
 then
 	echo "error: the '--series' option is required by ubuntu-old-fashioned" >&2
-	print-usage
+	print_usage
 	exit 255
 fi
 

--- a/scripts/ubuntu-bartender/ubuntu-disco-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-disco-bartender
@@ -1,1 +1,0 @@
-ubuntu-bartender


### PR DESCRIPTION
- Break monolithic chunks of code up into functions
- Simplify argument parsing
- Dynamically generate list of valid flags for validation
- Validate ubuntu-old-fashioned flags
- Various little improvements
  - Fix warnings and errors reported by shellcheck
  - Break a few long lines
  - Add small delay for PPA to settle when installing
    old-fashioned-image build dependencies
  - Switch to tabs over spaces to make heredocs more readable
- Remove inadequate documentation in comments
  - We've outgrown trying to explain what this is in a comment at the
    top of the file. A proper README is in order.
- Set TRACE to enable script debugging output
- Drop scripts for Disco, which is EOL