### PR TITLE
Add AWS provider options and config file reading

### DIFF
--- a/scripts/ubuntu-bartender/README.md
+++ b/scripts/ubuntu-bartender/README.md
@@ -108,8 +108,8 @@ AWS is faster - the cloud has fast in-cloud mirrors of the apt repositories, whi
 ## Configuration
 You may find more yourself passing in the same arguments over and over again. To help out, Bartender will check a couple places for configuration files:
 
-* `~/.bartender.rc`
-* `/etc/ubuntu-bartender/bartender.rc`
+* `~/.ubuntu-bartender.rc`
+* `/etc/ubuntu-bartender/ubuntu-bartender.rc`
 
 Configuration hierarchy is (listed in order of resolution)
 1. DEFAULTS

--- a/scripts/ubuntu-bartender/README.md
+++ b/scripts/ubuntu-bartender/README.md
@@ -105,6 +105,25 @@ Multipass is more convenient - all of your VMs run locally and it's free.
 
 AWS is faster - the cloud has fast in-cloud mirrors of the apt repositories, which dramatically reduces the time it takes to build an image.
 
+## Configuration
+You may find more yourself passing in the same arguments over and over again. To help out, Bartender will check a couple places for configuration files:
+
+* `~/.bartender.rc`
+* `/etc/ubuntu-bartender/bartender.rc`
+
+Configuration hierarchy is (listed in order of resolution)
+1. DEFAULTS
+2. Configuration File
+3. CLI
+
+### Configuring Providers
+Provider options are prepended with the provider name. example `AWS_PROFILE`. This allows you to, for example, set your profile and keypair name for interacting with AWS. In a config file:
+
+```
+AWS_PROFILE=work_account
+AWS_KEYPAIR_NAME=aws_testing_keypair
+```
+
 ## More questions?
 
 Feel free to open an issue and we can add more to the README.

--- a/scripts/ubuntu-bartender/aws-provider
+++ b/scripts/ubuntu-bartender/aws-provider
@@ -1,7 +1,7 @@
 function _find-ami() {
-  AMI_FILTERS="--filters Name=name,Values=ubuntu/images-testing/hvm-ssd/ubuntu-xenial-daily-amd64-server-*"
+  AMI_FILTERS="--filters Name=name,Values=$AWS_AMI_NAME_FILTER"
   aws --region "$region" ec2 describe-images \
-      --owners 099720109477 $AMI_FILTERS --output json |
+      --owners "$AWS_AMI_OWNER" $AMI_FILTERS --output json |
     jq -r '.Images | sort_by(.["CreationDate"])[-1].ImageId'
 }
 
@@ -53,12 +53,12 @@ function build-provider-assert-ready {
     exit 255
   fi
 
-  if ! aws ec2 describe-key-pairs --key-names "$USER" 2>/dev/null >/dev/null; then
-    echo "error: no registered keypair available for $USER" >&2
+  if ! aws --profile "$AWS_PROFILE" ec2 describe-key-pairs --key-names "$AWS_KEYPAIR_NAME" 2>/dev/null >/dev/null; then
+    echo "error: no registered keypair named $AWS_KEYPAIR_NAME" >&2
     exit 255
   fi
 
-  region=$(aws configure get region)
+  region=$(aws --profile "$AWS_PROFILE" configure get region)
 }
 
 function build-provider-destroy {
@@ -72,15 +72,17 @@ function build-provider-destroy {
 function build-provider-create {
   echo "Creating $1 on AWS..."
   instance_id=$(aws --output json --region "$region" \
+                    --profile "$AWS_PROFILE" \
                     ec2 run-instances \
-                    --key-name "$USER" \
+                    --key-name "$AWS_KEYPAIR_NAME" \
                     --instance-type m5.large \
                     --image-id "$(_find-ami)" \
                     --block-device-mappings "DeviceName=/dev/sda1,Ebs={VolumeSize=50,VolumeType=gp2}" \
                     --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$1}]" |
                   jq -r '.Instances[0].InstanceId')
   _wait-instance-running
-  ip_addr=$(aws --output json --region "$region" ec2 describe-instances \
+  ip_addr=$(aws --profile $AWS_PROFILE --output json --region "$region" \
+                ec2 describe-instances \
                 --instance-ids "$instance_id" |
               jq -r '.Reservations[0].Instances[0].PublicIpAddress')
   _wait-instance-connectable

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -96,6 +96,7 @@ fi
 # AWS SPECIFIC DEFAULTS
 AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-xenial-daily-amd64-server-*"
 AWS_PROFILE="default"
+# Official Canonical OwnerId
 AWS_AMI_OWNER=099720109477
 AWS_KEYPAIR_NAME=$USER
 

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -144,22 +144,22 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
                                             after the build completes.
                                             Value: Cleanup? $SHOULD_CLEANUP
 
-    --aws-ami-filter-name <image-name>      Image name for finding an AWS ami
+    --aws-ami-name-filter <image-name>      Filter for finding an AWS ami by name
                                             defaults to Xenial AMD64. This is
                                             the base for the builds
-                                            Value: $AWS-AMI-FILTER-NAME
+                                            Value: $AWS_AMI_NAME_FILTER
 
     --aws-profile <profile>                 AWS profile used with the aws cli
-                                            Value: $AWS-PROFILE
+                                            Value: $AWS_PROFILE
 
     --aws-ami-owner <owner_id>              AWS OwnerId, user in conjunction with
                                             --aws-ami-filter-name to find a base image
                                             for building. Defaults to Canonical
-                                            Value: $AWS-AMI-OWNER
+                                            Value: $AWS_AMI_OWNER
 
     --aws-keypair-name                      Keypair name associated with AWS profile
                                             Default is $USER       
-                                            Value: $AWS-KEYPAIR-NAME
+                                            Value: $AWS_KEYPAIR_NAME
 
     --help                                  Print this help message.
 
@@ -233,7 +233,7 @@ do
     --no-cleanup)
       SHOULD_CLEANUP=NO
       ;;
-    --aws-ami-filter-name)
+    --aws-ami-name-filter)
       AWS_AMI_NAME_FILTER="$2"
       shift
       ;;

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -172,7 +172,7 @@ EOF
 # Check/etc and user home. 
 # user home takes precedence over etc
 # Order is important as well, cli args win
-POSSIBLE_CONF_FILES=("/etc/ubuntu-bartender/bartender.rc" ~/".bartender.rc")
+POSSIBLE_CONF_FILES=("/etc/ubuntu-bartender/ubuntu-bartender.rc" ~/".ubuntu-bartender.rc")
 for file in "${POSSIBLE_CONF_FILES[@]}"
 do
   if [[ -f "${file}" ]]; then

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -86,6 +86,19 @@ else
   LIVECD_ROOTFS_BRANCH=${LIVECD_ROOTFS_BRANCH:-ubuntu/master}
 fi
 
+
+############ Provider Configuration ##########################################
+
+# Providers also have some config
+# This sets default values, and allows for inclusion in CLI and file
+# Please preface each provider default with the provider name
+
+# AWS SPECIFIC DEFAULTS
+AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-xenial-daily-amd64-server-*"
+AWS_PROFILE="default"
+AWS_AMI_OWNER=099720109477
+AWS_KEYPAIR_NAME=$USER
+
 # We also pull in explicitly set variables on the command line
 
 function print-usage {
@@ -130,12 +143,42 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
                                             after the build completes.
                                             Value: Cleanup? $SHOULD_CLEANUP
 
+    --aws-ami-filter-name <image-name>      Image name for finding an AWS ami
+                                            defaults to Xenial AMD64. This is
+                                            the base for the builds
+                                            Value: $AWS-AMI-FILTER-NAME
+
+    --aws-profile <profile>                 AWS profile used with the aws cli
+                                            Value: $AWS-PROFILE
+
+    --aws-ami-owner <owner_id>              AWS OwnerId, user in conjunction with
+                                            --aws-ami-filter-name to find a base image
+                                            for building. Defaults to Canonical
+                                            Value: $AWS-AMI-OWNER
+
+    --aws-keypair-name                      Keypair name associated with AWS profile
+                                            Default is $USER       
+                                            Value: $AWS-KEYPAIR-NAME
+
     --help                                  Print this help message.
 
 Options specified after '--' separator are used by Ubuntu Old Fashioned directly.
 
 EOF
 }
+
+# These can be added to a config file as well
+# Check/etc and user home. 
+# user home takes precedence over etc
+# Order is important as well, cli args win
+POSSIBLE_CONF_FILES=("/etc/ubuntu-bartender/bartender.rc" ~/".bartender.rc")
+for file in "${POSSIBLE_CONF_FILES[@]}"
+do
+  if [[ -f "${file}" ]]; then
+    echo "Sourcing configuration file: $file"
+    source $file
+  fi
+done
 
 # Which we parse with the typical boilerplate:
 
@@ -188,6 +231,22 @@ do
       ;;
     --no-cleanup)
       SHOULD_CLEANUP=NO
+      ;;
+    --aws-ami-filter-name)
+      AWS_AMI_NAME_FILTER="$2"
+      shift
+      ;;
+    --aws-profile)
+      AWS_PROFILE="$2"
+      shift
+      ;;
+    --aws-ami-owner)
+      AWS_AMI_OWNER="$2"
+      shift
+      ;;
+    --aws-keypair-name)
+      AWS_KEYPAIR_NAME="$2"
+      shift
       ;;
     --)
       shift


### PR DESCRIPTION
Providers had hardcoded values. This made configuration of the provider
a bit of a chore, for instance if you had specific keynames or profile
you wanted to use. This allows users to set some AWS provider option via
CLI or via file. Config file sourcing was added for long living options,
such as AWS_PROFILE and AWS_KEYPAIR_NAME. The addition of AWS_AMI_OWNER
and AWS_AMI_FILTER_NAME gives flexibility when testing, including
searching for an ARM base, or using an experimental base for a build (by
using a non-Canonical official OwnerID for AWS_AMI_OWNER)