### PR TITLE
Switch to production launchpad build tools

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -130,7 +130,7 @@ DEPENDENCIES=(launchpad-buildd bzr python-ubuntutools)
 for dep in ${DEPENDENCIES[@]} ; do
     if ! [[ $(dpkg -l | grep ^ii | grep $dep) != "" ]] ; then
         echo "Please install the required dependencies for this script:"
-        echo "  sudo add-apt-repository -y -u ppa:launchpad/ppa"
+        echo "  sudo add-apt-repository -y -u ppa:canonical-is-sa/ubuntu/buildd"
         echo "  sudo apt install -y ${DEPENDENCIES[@]}"
         exit 1
     fi

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -316,7 +316,7 @@ build-provider-create $bartender_name
 
   cat > mix-old-fashioned << EOF
 #!/bin/bash -x
-sudo add-apt-repository -y -u ppa:launchpad/ppa
+sudo add-apt-repository -y -u ppa:canonical-is-sa/ubuntu/buildd
 sudo apt-get -q update
 sudo apt-get -q install -y launchpad-buildd bzr python-ubuntutools git python3-ubuntutools python3-launchpadlib
 cd livecd-rootfs

--- a/setup-old-fashioned
+++ b/setup-old-fashioned
@@ -18,7 +18,7 @@ from typing import Dict, List, Text, Tuple  # noqa
 
 PKG_INSTALL_CMDS = [
     ["sudo", "add-apt-repository", "-y", "ppa:cloud-images/old-fashioned"],
-    ["sudo", "add-apt-repository", "-y", "ppa:launchpad/ppa"],
+    ["sudo", "add-apt-repository", "-y", "ppa:canonical-is-sa/ubuntu/buildd"],
     ["sudo", "apt-get", "update"],
     ["sudo", "apt-get", "install", "-y", "oldfashioned"],
     ["sudo", "apt-get", "install", "-y", "launchpad-buildd", "bzr",


### PR DESCRIPTION
We were using ppa:launchpad/ppa, which contains unverified automatic
builds of launchpad tools. Instead, we should be using the builds from
ppa:canonical-is-sa/ubuntu/buildd, which are the tools that feed into
the production build farm.