### PR TITLE
Add missing py3 deps

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -125,7 +125,7 @@ if [ x$SERIES = "x" ] ; then
     exit 1
 fi
 
-DEPENDENCIES=(launchpad-buildd bzr python-ubuntutools)
+DEPENDENCIES=(launchpad-buildd bzr python3-ubuntutools python3-launchpadlib)
 
 for dep in ${DEPENDENCIES[@]} ; do
     if ! [[ $(dpkg -l | grep ^ii | grep $dep) != "" ]] ; then

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -318,7 +318,7 @@ build-provider-create $bartender_name
 #!/bin/bash -x
 sudo add-apt-repository -y -u ppa:canonical-is-sa/ubuntu/buildd
 sudo apt-get -q update
-sudo apt-get -q install -y launchpad-buildd bzr python-ubuntutools git python3-ubuntutools python3-launchpadlib
+sudo apt-get -q install -y launchpad-buildd bzr git python3-ubuntutools python3-launchpadlib
 cd livecd-rootfs
 sudo -E ../ubuntu-old-fashioned/old-fashioned-image-build --no-cleanup $chroot_archive_flag $series_flag $@
 EOF

--- a/setup-old-fashioned
+++ b/setup-old-fashioned
@@ -22,7 +22,7 @@ PKG_INSTALL_CMDS = [
     ["sudo", "apt-get", "update"],
     ["sudo", "apt-get", "install", "-y", "oldfashioned"],
     ["sudo", "apt-get", "install", "-y", "launchpad-buildd", "bzr",
-     "python-ubuntutools", "distro-info",
+     "python3-ubuntutools", "python3-launchpadlib", "distro-info",
      ],
 ]
 


### PR DESCRIPTION
Commit 7d2dd06 updated bartender for the py2->3 migration of ubuntutools
and launchpadlib but missed a few couple of other places that would only
be seen if running setup and builds without bartender.  This patch
migrates those to py3 dependencies as well.

Additionally the older python2 package was not removed.  That package is 
not required after the py3 migration and is dropped by these commits.
