### PR TITLE
Upgrade build environment to Bionic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ manage the Ubuntu Old Fashioned build for you.
 
 ## Installation
 
-On Ubuntu (**only works for Xenial**):
+On Ubuntu (**only works for Bionic or Xenial**):
 
 The easiest way to install is to use the included setup script:
 

--- a/scripts/ubuntu-bartender/README.md
+++ b/scripts/ubuntu-bartender/README.md
@@ -26,7 +26,7 @@ Absolutely. Here's an incomplete, high-level overview of the components
 of an Ubuntu image build with Ubuntu Bartender:
 
 #### [Ubuntu Bartender][3]
-- Manages the lifecycle of a xenial VM in which the image build is run
+- Manages the lifecycle of a bionic VM in which the image build is run
 - Collects the dependencies of an Ubuntu Old Fashioned image build
 - Runs an Ubuntu Old Fashioned image build
 - Downloads any artifacts produced by the build
@@ -99,7 +99,7 @@ ubuntu-bartender --help
 
 ## You mentioned an example specifying different build providers. Why does that matter?
 
-The Ubuntu image build happens in a LXD container within a xenial VM. Ubuntu Bartender can manage the lifecycle of that VM, which can run in either [Multipass][7] or [AWS][8].
+The Ubuntu image build happens in a LXD container within a bionic VM. Ubuntu Bartender can manage the lifecycle of that VM, which can run in either [Multipass][7] or [AWS][8].
 
 Multipass is more convenient - all of your VMs run locally and it's free.
 

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -94,7 +94,7 @@ fi
 # Please preface each provider default with the provider name
 
 # AWS SPECIFIC DEFAULTS
-AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-xenial-daily-amd64-server-*"
+AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-bionic-daily-amd64-server-*"
 AWS_PROFILE="default"
 # Official Canonical OwnerId
 AWS_AMI_OWNER=099720109477

--- a/setup-old-fashioned
+++ b/setup-old-fashioned
@@ -93,8 +93,9 @@ def ubuntu_distro_info(options):
 
 
 if __name__ == '__main__':
-    if '16.04' not in platform.linux_distribution():
-        print("Old-fashioned must be run on Xenial Ubuntu.")
+    version = platform.linux_distribution()
+    if '18.04' not in version and '16.04' not in version:
+        print("Old-fashioned must be run on Bionic or Xenial Ubuntu.")
         exit(1)
 
     for cmd in PKG_INSTALL_CMDS:


### PR DESCRIPTION
The Launchpad builders are upgrading to Bionic:

> The VMs in Launchpad's build farm have been on Ubuntu 16.04 (xenial) for
some time.  We're intentionally fairly conservative about upgrading the
base VMs, but it's about time to have something newer, so we've just
upgraded them to Ubuntu 18.04 (bionic).

This will upgrade old-fashioned to match.