### PR TITLE
Add a parameter to bartender to specify where the temp dir should be

### DIFF
--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -160,7 +160,11 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
     --aws-keypair-name                      Keypair name associated with AWS profile
                                             Default is $USER       
                                             Value: $AWS_KEYPAIR_NAME
-
+    --temp-dir-loc                          Parent folder to build the temp dir used
+                                            by bartender; note that this must be
+                                            a directory that multipass (a strictly-
+                                            confined snap) can access
+                                            Value: $HOME
     --help                                  Print this help message.
 
 Options specified after '--' separator are used by Ubuntu Old Fashioned directly.
@@ -247,6 +251,10 @@ do
       ;;
     --aws-keypair-name)
       AWS_KEYPAIR_NAME="$2"
+      shift
+      ;;
+    --temp-dir-loc)
+      HOME="$2"
       shift
       ;;
     --)

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -74,6 +74,9 @@ BUILD_PROVIDER=${BUILD_PROVIDER:-multipass}
 
 SHOULD_CLEANUP=${SHOULD_CLEANUP:-YES}
 
+# Where to build the ingredients.tar.gz file
+TEMP_DIR_LOC=$HOME
+
 # Parse the name of the script to see if we can infer some variables
 
 maybe_series=$(basename $0 | cut -d'-' -f2)
@@ -254,7 +257,7 @@ do
       shift
       ;;
     --temp-dir-loc)
-      HOME="$2"
+      TEMP_DIR_LOC="$2"
       shift
       ;;
     --)
@@ -313,7 +316,7 @@ fi
 
 # Let's build all the things!
 
-temp_dir=$(mktemp --tmpdir="$HOME" --directory ubuntu-bartender-multipass.XXXXXXXXXX)
+temp_dir=$(mktemp --tmpdir="$TEMP_DIR_LOC" --directory ubuntu-bartender-multipass.XXXXXXXXXX)
 bartender_name=$(petname)-ubuntu-bartender
 drink_name=${bartender_name/-bartender/-on-the-rocks.tar.gz}
 

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -167,7 +167,7 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
                                             by bartender; note that this must be
                                             a directory that multipass (a strictly-
                                             confined snap) can access
-                                            Value: $HOME
+                                            Value: $TEMP_DIR_LOC
     --help                                  Print this help message.
 
 Options specified after '--' separator are used by Ubuntu Old Fashioned directly.


### PR DESCRIPTION
This solves a problem that came up when my primary disk was close to full, and bartender was building the `ingredients.tar.gz` file (which can be quite large) in my home directory, and then getting errors because my disk was full. This additional argument allows the user to specify another directory (accessible by the strictly-confined multipass snap, e.g. another drive mounted somewhere in the home dir) in which to build the ingredients file.