### PR TITLE
Populate aws key variable down to aws-provider scripts

### DIFF
--- a/scripts/ubuntu-bartender/aws-provider
+++ b/scripts/ubuntu-bartender/aws-provider
@@ -25,8 +25,13 @@ function _wait-instance-running() {
 }
 
 function _wait-instance-connectable() {
+  key_opt=''
+  if [ -f ~/.ssh/${AWS_KEYPAIR_NAME}.pem ]; then
+    key_opt="-i ~/.ssh/${AWS_KEYPAIR_NAME}.pem"
+  fi
+
   for attempt in $(seq 12); do
-    if ! ssh -i ~/.ssh/${AWS_KEYPAIR_NAME}.pem -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
+    if ! ssh ${key_opt} -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
       sleep 10 
     else
       state=connectable
@@ -89,15 +94,30 @@ function build-provider-create {
 }
 
 function build-provider-upload {
-  scp -v -i ~/.ssh/${AWS_KEYPAIR_NAME}.pem -qo StrictHostKeyChecking=no "$2" "ubuntu@$ip_addr:$3"
+  key_opt=''
+  if [ -f ~/.ssh/${AWS_KEYPAIR_NAME}.pem ]; then
+    key_opt="-i ~/.ssh/${AWS_KEYPAIR_NAME}.pem"
+  fi
+
+  scp ${key_opt} -qo StrictHostKeyChecking=no "$2" "ubuntu@$ip_addr:$3"
 }
 
 function build-provider-download {
-  scp -v -i ~/.ssh/${AWS_KEYPAIR_NAME}.pem -qo StrictHostKeyChecking=no "ubuntu@$ip_addr:$2" "$3"
+  key_opt=''
+  if [ -f ~/.ssh/${AWS_KEYPAIR_NAME}.pem ]; then
+    key_opt="-i ~/.ssh/${AWS_KEYPAIR_NAME}.pem"
+  fi
+
+  scp ${key_opt} -qo StrictHostKeyChecking=no "ubuntu@$ip_addr:$2" "$3"
 }
 
 function build-provider-run {
+  key_opt=''
+  if [ -f ~/.ssh/${AWS_KEYPAIR_NAME}.pem ]; then
+    key_opt="-i ~/.ssh/${AWS_KEYPAIR_NAME}.pem"
+  fi
+
   args=$(echo -- $@ | sed 's/.*--//')
-  ssh -i ~/.ssh/${AWS_KEYPAIR_NAME}.pem -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- $args
+  ssh ${key_opt} -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- $args
 }
 

--- a/scripts/ubuntu-bartender/aws-provider
+++ b/scripts/ubuntu-bartender/aws-provider
@@ -25,13 +25,10 @@ function _wait-instance-running() {
 }
 
 function _wait-instance-connectable() {
-  key_opt=''
-  if [ -f ~/.ssh/${AWS_KEYPAIR_NAME}.pem ]; then
-    key_opt="-i ~/.ssh/${AWS_KEYPAIR_NAME}.pem"
-  fi
+  set-key-opt
 
   for attempt in $(seq 12); do
-    if ! ssh ${key_opt} -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
+    if ! ssh ${KEY_OPT} -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
       sleep 10 
     else
       state=connectable
@@ -94,30 +91,27 @@ function build-provider-create {
 }
 
 function build-provider-upload {
-  key_opt=''
-  if [ -f ~/.ssh/${AWS_KEYPAIR_NAME}.pem ]; then
-    key_opt="-i ~/.ssh/${AWS_KEYPAIR_NAME}.pem"
-  fi
+  set-key-opt
 
-  scp ${key_opt} -qo StrictHostKeyChecking=no "$2" "ubuntu@$ip_addr:$3"
+  scp ${KEY_OPT} -qo StrictHostKeyChecking=no "$2" "ubuntu@$ip_addr:$3"
 }
 
 function build-provider-download {
-  key_opt=''
-  if [ -f ~/.ssh/${AWS_KEYPAIR_NAME}.pem ]; then
-    key_opt="-i ~/.ssh/${AWS_KEYPAIR_NAME}.pem"
-  fi
+  set-key-opt
 
-  scp ${key_opt} -qo StrictHostKeyChecking=no "ubuntu@$ip_addr:$2" "$3"
+  scp ${KEY_OPT} -qo StrictHostKeyChecking=no "ubuntu@$ip_addr:$2" "$3"
 }
 
 function build-provider-run {
-  key_opt=''
-  if [ -f ~/.ssh/${AWS_KEYPAIR_NAME}.pem ]; then
-    key_opt="-i ~/.ssh/${AWS_KEYPAIR_NAME}.pem"
-  fi
+  set-key-opt
 
   args=$(echo -- $@ | sed 's/.*--//')
-  ssh ${key_opt} -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- $args
+  ssh ${KEY_OPT} -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- $args
 }
 
+function set-key-opt() {
+  export KEY_OPT=''
+  if [ -f ~/.ssh/${AWS_KEYPAIR_NAME}.pem ]; then
+    KEY_OPT="-i ~/.ssh/${AWS_KEYPAIR_NAME}.pem"
+  fi
+}

--- a/scripts/ubuntu-bartender/aws-provider
+++ b/scripts/ubuntu-bartender/aws-provider
@@ -26,7 +26,7 @@ function _wait-instance-running() {
 
 function _wait-instance-connectable() {
   for attempt in $(seq 12); do
-    if ! ssh -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
+    if ! ssh -i ~/.ssh/${AWS_KEYPAIR_NAME}.pem -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
       sleep 10 
     else
       state=connectable
@@ -89,15 +89,15 @@ function build-provider-create {
 }
 
 function build-provider-upload {
-  scp -qo StrictHostKeyChecking=no "$2" "ubuntu@$ip_addr:$3"
+  scp -v -i ~/.ssh/${AWS_KEYPAIR_NAME}.pem -qo StrictHostKeyChecking=no "$2" "ubuntu@$ip_addr:$3"
 }
 
 function build-provider-download {
-  scp -qo StrictHostKeyChecking=no "ubuntu@$ip_addr:$2" "$3"
+  scp -v -i ~/.ssh/${AWS_KEYPAIR_NAME}.pem -qo StrictHostKeyChecking=no "ubuntu@$ip_addr:$2" "$3"
 }
 
 function build-provider-run {
   args=$(echo -- $@ | sed 's/.*--//')
-  ssh -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- $args
+  ssh -i ~/.ssh/${AWS_KEYPAIR_NAME}.pem -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- $args
 }
 

--- a/scripts/ubuntu-bartender/aws-provider
+++ b/scripts/ubuntu-bartender/aws-provider
@@ -25,8 +25,6 @@ function _wait-instance-running() {
 }
 
 function _wait-instance-connectable() {
-  set-key-opt
-
   for attempt in $(seq 12); do
     if ! ssh $(set-key-opt) -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
       sleep 10 

--- a/scripts/ubuntu-bartender/aws-provider
+++ b/scripts/ubuntu-bartender/aws-provider
@@ -28,7 +28,7 @@ function _wait-instance-connectable() {
   set-key-opt
 
   for attempt in $(seq 12); do
-    if ! ssh ${KEY_OPT} -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
+    if ! ssh $(set-key-opt) -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- true; then
       sleep 10 
     else
       state=connectable
@@ -91,22 +91,16 @@ function build-provider-create {
 }
 
 function build-provider-upload {
-  set-key-opt
-
-  scp ${KEY_OPT} -qo StrictHostKeyChecking=no "$2" "ubuntu@$ip_addr:$3"
+  scp $(set-key-opt) -qo StrictHostKeyChecking=no "$2" "ubuntu@$ip_addr:$3"
 }
 
 function build-provider-download {
-  set-key-opt
-
-  scp ${KEY_OPT} -qo StrictHostKeyChecking=no "ubuntu@$ip_addr:$2" "$3"
+  scp $(set-key-opt) -qo StrictHostKeyChecking=no "ubuntu@$ip_addr:$2" "$3"
 }
 
 function build-provider-run {
-  set-key-opt
-
   args=$(echo -- $@ | sed 's/.*--//')
-  ssh ${KEY_OPT} -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- $args
+  ssh $(set-key-opt) -qo StrictHostKeyChecking=no "ubuntu@$ip_addr" -- $args
 }
 
 function set-key-opt() {
@@ -114,4 +108,6 @@ function set-key-opt() {
   if [ -f ~/.ssh/${AWS_KEYPAIR_NAME}.pem ]; then
     KEY_OPT="-i ~/.ssh/${AWS_KEYPAIR_NAME}.pem"
   fi
+
+  echo ${KEY_OPT}
 }

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -157,7 +157,9 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
                                             for building. Defaults to Canonical
                                             Value: $AWS_AMI_OWNER
 
-    --aws-keypair-name                      Keypair name associated with AWS profile
+    --aws-keypair-name                      Keypair name associated with AWS profile;
+                                            local private key must be a .pem
+                                            with chmod 400 in ~/.ssh/
                                             Default is $USER       
                                             Value: $AWS_KEYPAIR_NAME
 


### PR DESCRIPTION
I've tested this in practice using the aws provider by building a bartender build, in this case of the azure-base project of xenial.

Prior to this change, the commands to ssh and scp in the aws-provider were failing to connect to the instance.

I ran my test build using the default $USER -named key, i.e. I did not specify --aws-keypair-name in the bartender build.