### PR TITLE
Enable building from -proposed with old-fashioned

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -10,6 +10,7 @@
 IMG_FORMAT="ext4"
 PROJECT="ubuntu-cpc"
 SUBPROJECT=""
+PROPOSED=""
 SERIES=""
 USE_CHROOT_CACHE=false
 CLEANUP=true
@@ -23,6 +24,10 @@ while :; do
         --minimized)
             # Pass this flag to build the 'minimal' image family
             SUBPROJECT="--subproject minimized"
+            ;;
+        --proposed)
+            # Build from -proposed pocket
+            PROPOSED="--proposed"
             ;;
         --subproject)
             # Depends on project
@@ -199,11 +204,20 @@ export MIRROR=$(egrep "(archive|ports)" /etc/apt/sources.list|head -1 | \
 export MIRROR_PATH=$(egrep "(archive|ports)" /etc/apt/sources.list|head -1 | \
                cut -d' ' -f2 | cut -d'/' -f4)
 
-/usr/share/launchpad-buildd/bin/in-target override-sources-list \
-  --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME \
-    "deb http://$MIRROR/${MIRROR_PATH} $SERIES main restricted universe multiverse" \
-    "deb http://$MIRROR/${MIRROR_PATH} $SERIES-security main restricted universe multiverse" \
-    "deb http://$MIRROR/${MIRROR_PATH} $SERIES-updates main restricted universe multiverse"
+if [ -n "$PROPOSED" ]; then
+  /usr/share/launchpad-buildd/bin/in-target override-sources-list \
+    --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME \
+      "deb http://$MIRROR/${MIRROR_PATH} $SERIES main restricted universe multiverse" \
+      "deb http://$MIRROR/${MIRROR_PATH} $SERIES-proposed main restricted universe multiverse" \
+      "deb http://$MIRROR/${MIRROR_PATH} $SERIES-security main restricted universe multiverse" \
+      "deb http://$MIRROR/${MIRROR_PATH} $SERIES-updates main restricted universe multiverse"
+else
+  /usr/share/launchpad-buildd/bin/in-target override-sources-list \
+    --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME \
+      "deb http://$MIRROR/${MIRROR_PATH} $SERIES main restricted universe multiverse" \
+      "deb http://$MIRROR/${MIRROR_PATH} $SERIES-security main restricted universe multiverse" \
+      "deb http://$MIRROR/${MIRROR_PATH} $SERIES-updates main restricted universe multiverse"
+fi
 
 /usr/share/launchpad-buildd/bin/in-target update-debian-chroot \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME
@@ -237,7 +251,7 @@ time /usr/share/launchpad-buildd/bin/in-target buildlivefs \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME $HTTP_PROXY \
   --project $PROJECT $SUBPROJECT --datestamp $SERIAL --image-format $IMG_FORMAT \
   $EXTRA_PPA \
-  $IMAGE_TARGET $REPO_SNAPSHOT $SNAP_COHORT
+  $IMAGE_TARGET $REPO_SNAPSHOT $SNAP_COHORT $PROPOSED
 
 echo "Copying files out to $OUTPUT_DIRECTORY"
 rm -rf $OUTPUT_DIRECTORY

--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -217,7 +217,7 @@ if [ "$PROPOSED_IN_IMAGE" = "true" ]; then
 fi
 
 /usr/share/launchpad-buildd/bin/in-target override-sources-list \
-  --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME ${sources} \
+  --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME \
     "deb http://$MIRROR/${MIRROR_PATH} $SERIES main restricted universe multiverse" \
     "deb http://$MIRROR/${MIRROR_PATH} $SERIES-security main restricted universe multiverse" \
     "deb http://$MIRROR/${MIRROR_PATH} $SERIES-updates main restricted universe multiverse" \

--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -10,7 +10,8 @@
 IMG_FORMAT="ext4"
 PROJECT="ubuntu-cpc"
 SUBPROJECT=""
-PROPOSED=""
+PROPOSED_BUILD=""
+PROPOSED_IN_IMAGE="false"
 SERIES=""
 USE_CHROOT_CACHE=false
 CLEANUP=true
@@ -25,9 +26,14 @@ while :; do
             # Pass this flag to build the 'minimal' image family
             SUBPROJECT="--subproject minimized"
             ;;
-        --proposed)
+        --build-from-proposed)
             # Build from -proposed pocket
-            PROPOSED="--proposed"
+            PROPOSED_BUILD="--proposed"
+            ;;
+        --enable-proposed-in-image)
+            # Enable the -proposed pocket in the image(s) produced from the
+            # build
+            PROPOSED_IN_IMAGE="true"
             ;;
         --subproject)
             # Depends on project
@@ -204,21 +210,19 @@ export MIRROR=$(egrep "(archive|ports)" /etc/apt/sources.list|head -1 | \
 export MIRROR_PATH=$(egrep "(archive|ports)" /etc/apt/sources.list|head -1 | \
                cut -d' ' -f2 | cut -d'/' -f4)
 
-if [ -n "$PROPOSED" ]; then
-  /usr/share/launchpad-buildd/bin/in-target override-sources-list \
-    --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME \
-      "deb http://$MIRROR/${MIRROR_PATH} $SERIES main restricted universe multiverse" \
-      "deb http://$MIRROR/${MIRROR_PATH} $SERIES-proposed main restricted universe multiverse" \
-      "deb http://$MIRROR/${MIRROR_PATH} $SERIES-security main restricted universe multiverse" \
-      "deb http://$MIRROR/${MIRROR_PATH} $SERIES-updates main restricted universe multiverse"
-else
-  /usr/share/launchpad-buildd/bin/in-target override-sources-list \
-    --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME \
-      "deb http://$MIRROR/${MIRROR_PATH} $SERIES main restricted universe multiverse" \
-      "deb http://$MIRROR/${MIRROR_PATH} $SERIES-security main restricted universe multiverse" \
-      "deb http://$MIRROR/${MIRROR_PATH} $SERIES-updates main restricted universe multiverse"
+proposed_source=""
+
+if [ "$PROPOSED_IN_IMAGE" = "true" ]; then
+  proposed_source="deb http://$MIRROR/${MIRROR_PATH} $SERIES-proposed main restricted universe multiverse"
 fi
 
+/usr/share/launchpad-buildd/bin/in-target override-sources-list \
+  --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME ${sources} \
+    "deb http://$MIRROR/${MIRROR_PATH} $SERIES main restricted universe multiverse" \
+    "deb http://$MIRROR/${MIRROR_PATH} $SERIES-security main restricted universe multiverse" \
+    "deb http://$MIRROR/${MIRROR_PATH} $SERIES-updates main restricted universe multiverse" \
+    "${proposed_source}"
+  
 /usr/share/launchpad-buildd/bin/in-target update-debian-chroot \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME
 
@@ -251,7 +255,7 @@ time /usr/share/launchpad-buildd/bin/in-target buildlivefs \
   --backend=lxd --series=$SERIES --arch=${ARCH} $LIVEFS_NAME $HTTP_PROXY \
   --project $PROJECT $SUBPROJECT --datestamp $SERIAL --image-format $IMG_FORMAT \
   $EXTRA_PPA \
-  $IMAGE_TARGET $REPO_SNAPSHOT $SNAP_COHORT $PROPOSED
+  $IMAGE_TARGET $REPO_SNAPSHOT $SNAP_COHORT $PROPOSED_BUILD
 
 echo "Copying files out to $OUTPUT_DIRECTORY"
 rm -rf $OUTPUT_DIRECTORY


### PR DESCRIPTION
The launchpad-buildd supports a `--proposed` flag, and oftentimes it is desirable to do old-fashioned builds against -proposed. As far as I can tell, enabling this amounts to overriding the sources list (thanks John) and passing the flag down to the `buildlivefs` launchpad-buildd in-target operation.

I've tested these changes by building the xenial azure-base target with bartender. I modified the Makefile in secret sauce to explicitly pass the `--proposed` flag as an `old_fashioned_flags` append. I've verified that the package versions in the resulting manifest are from -proposed where expected.