### PR TITLE
Don't use the apt proxy for other things

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -186,7 +186,6 @@ SQUID_ADDRESS=$(cat /etc/apt/apt.conf.d/* | sed -n 's/Acquire::http::Proxy "\(.*
 SQUID_TMP_CONFIG=/tmp/30squid-proxy
 HTTP_PROXY=""
 if [ x"$SQUID_ADDRESS" != 'x' ] ; then
-    HTTP_PROXY="--http-proxy=$SQUID_ADDRESS"
     cat > /tmp/30squid-proxy << EOF
 Acquire::http::Proxy "$SQUID_ADDRESS";
 EOF


### PR DESCRIPTION
Using b2eb76b5bef and trying to build an hirsute desktop ISO with squid-deb-proxy configured as hinted in the instruction the build fails

```
* Downloading http://people.canonical.com/~ubuntu-archive/seeds/ubuntu.hirsute/STRUCTURE
! Could not open (any of):
!   http://people.canonical.com/~ubuntu-archive/seeds/ubuntu.hirsute/STRUCTURE
```

It's probably because the deb proxy shouldn't be used for non apt requests? The proposed change fixes the build while still having debs downloaded from the local proxy
