### PR TITLE
Don't use the apt proxy for other things

### DIFF
--- a/old-fashioned-image-build
+++ b/old-fashioned-image-build
@@ -186,11 +186,11 @@ SQUID_ADDRESS=$(cat /etc/apt/apt.conf.d/* | sed -n 's/Acquire::http::Proxy "\(.*
 SQUID_TMP_CONFIG=/tmp/30squid-proxy
 HTTP_PROXY=""
 if [ x"$SQUID_ADDRESS" != 'x' ] ; then
-    HTTP_PROXY="--http-proxy=$SQUID_ADDRESS"
     cat > /tmp/30squid-proxy << EOF
 Acquire::http::Proxy "$SQUID_ADDRESS";
 EOF
     lxc file push $SQUID_TMP_CONFIG lp-$SERIES-${ARCH}/etc/apt/apt.conf.d/30squid-proxy
+    lxc config set lp-$SERIES-${ARCH} environment.LB_APT_HTTP_PROXY "$SQUID_ADDRESS"
 fi
 
 # Use the same apt mirror as the host


### PR DESCRIPTION
Using b2eb76b and trying to build an hirsute desktop ISO with squid-deb-proxy configured as hinted in the instruction the build fails

* Downloading http://people.canonical.com/~ubuntu-archive/seeds/ubuntu.hirsute/STRUCTURE
! Could not open (any of):
!   http://people.canonical.com/~ubuntu-archive/seeds/ubuntu.hirsute/STRUCTURE

It's probably because the deb proxy shouldn't be used for non apt requests? The proposed change fixes the build while still having debs downloaded from the local proxy

launchpad-buildd uses the same http_proxy value to set LB_APT_HTTP_PROXY which is needed to get the live-build created chroot environments to use the apt proxy so setting that one through lxc instead