### PR TITLE
Update on Multipass providers

### DIFF
--- a/scripts/ubuntu-bartender/README.md
+++ b/scripts/ubuntu-bartender/README.md
@@ -122,6 +122,8 @@ Provider options are prepended with the provider name. example `AWS_PROFILE`. Th
 ```
 AWS_PROFILE=work_account
 AWS_KEYPAIR_NAME=aws_testing_keypair
+MULTIPASS_DISK_SIZE=50G
+MULTIPASS_MEM_SIZE=8G
 ```
 
 ## More questions?

--- a/scripts/ubuntu-bartender/README.md
+++ b/scripts/ubuntu-bartender/README.md
@@ -124,6 +124,7 @@ AWS_PROFILE=work_account
 AWS_KEYPAIR_NAME=aws_testing_keypair
 MULTIPASS_DISK_SIZE=multipass_disk_size
 MULTIPASS_MEM_SIZE=multipass_memory_size
+MULTIPASS_IMAGE=multipass_image
 ```
 
 ## More questions?

--- a/scripts/ubuntu-bartender/README.md
+++ b/scripts/ubuntu-bartender/README.md
@@ -122,8 +122,8 @@ Provider options are prepended with the provider name. example `AWS_PROFILE`. Th
 ```
 AWS_PROFILE=work_account
 AWS_KEYPAIR_NAME=aws_testing_keypair
-MULTIPASS_DISK_SIZE=50G
-MULTIPASS_MEM_SIZE=8G
+MULTIPASS_DISK_SIZE=multipass_disk_size
+MULTIPASS_MEM_SIZE=multipass_memory_size
 ```
 
 ## More questions?

--- a/scripts/ubuntu-bartender/multipass-provider
+++ b/scripts/ubuntu-bartender/multipass-provider
@@ -11,7 +11,7 @@ function build-provider-destroy {
 }
 
 function build-provider-create {
-  multipass launch --disk ${MULTIPASS_DISK_SIZE:-50G} --mem ${MULTIPASS_MEM_SIZE:-8G} --name "$1" daily:b
+  multipass launch --disk $MULTIPASS_DISK_SIZE --mem $MULTIPASS_MEM_SIZE --name "$1" $MULTIPASS_IMAGE
 }
 
 function build-provider-upload {

--- a/scripts/ubuntu-bartender/multipass-provider
+++ b/scripts/ubuntu-bartender/multipass-provider
@@ -11,7 +11,7 @@ function build-provider-destroy {
 }
 
 function build-provider-create {
-  multipass launch --disk 50G --mem 8G --name "$1" daily:x
+  multipass launch --disk ${MULTIPASS_DISK_SIZE:-50G} --mem ${MULTIPASS_DISK_SIZE:-8G} --name "$1" daily:b
 }
 
 function build-provider-upload {

--- a/scripts/ubuntu-bartender/multipass-provider
+++ b/scripts/ubuntu-bartender/multipass-provider
@@ -11,7 +11,7 @@ function build-provider-destroy {
 }
 
 function build-provider-create {
-  multipass launch --disk ${MULTIPASS_DISK_SIZE:-50G} --mem ${MULTIPASS_DISK_SIZE:-8G} --name "$1" daily:b
+  multipass launch --disk ${MULTIPASS_DISK_SIZE:-50G} --mem ${MULTIPASS_MEM_SIZE:-8G} --name "$1" daily:b
 }
 
 function build-provider-upload {

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -103,6 +103,11 @@ AWS_PROFILE="default"
 AWS_AMI_OWNER=099720109477
 AWS_KEYPAIR_NAME=$USER
 
+# MULTIPASS SPECIFIC DEFAULTS
+MULTIPASS_DISK_SIZE=50G
+MULTIPASS_MEM_SIZE=8G
+MULTIPASS_IMAGE=daily:b # daily image of bionic
+
 # We also pull in explicitly set variables on the command line
 
 function print-usage {

--- a/scripts/ubuntu-bartender/ubuntu-hirsute-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-hirsute-bartender
@@ -1,0 +1,1 @@
+ubuntu-bartender


### PR DESCRIPTION
1. use the daily bionic image instead; xenial is about EOL and do not have arm64 image.
2. add customizable options `MULTIPASS_DISK_SIZE` and `MULTIPASS_MEM_SIZE` for Multipass provider.
3. include a hirsute provider.
