### PR TITLE
Add arm configuration

### DIFF
--- a/scripts/ubuntu-bartender/README.md
+++ b/scripts/ubuntu-bartender/README.md
@@ -127,6 +127,18 @@ MULTIPASS_MEM_SIZE=multipass_memory_size
 MULTIPASS_IMAGE=multipass_image
 ```
 
+## ARM builds
+ARM is growing in support, and there is demand for builds. However, most of us do not have an ARM based daily driver for development. Thankfully, AWS to the rescue
+
+There is a quick option for calling up ARM defaults for aws, `--aws-arm-build` (AWS_ARM_BUILD). This is a boolean style flag, so via the cli, passing the flag is sufficient
+For configuration in file or env_var, please use true or false (literal strings). The only truthy value is the literal string "true". 
+
+This will run a build searching for an ARM based ami (`AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-bionic-daily-arm64-server-*"`) and 
+use an arm instance type (`AWS_INSTANCE_TYPE="m6g.large"`). This option is meant as a quick flag so you don't need to look up filter name or instance types.
+
+Know that setting `--aws-ami-name-filter` and `--aws-instance-type` **and** `--aws-arm-build` will result in the `--aws-arm-build` defaults being used, **not** your passed in values.
+If you want to set specifics, please use `--aws-ami-name-filter` and `--aws-instance-type` directly.
+
 ## More questions?
 
 Feel free to open an issue and we can add more to the README.

--- a/scripts/ubuntu-bartender/aws-provider
+++ b/scripts/ubuntu-bartender/aws-provider
@@ -75,7 +75,7 @@ function build-provider-create {
                     --profile "$AWS_PROFILE" \
                     ec2 run-instances \
                     --key-name "$AWS_KEYPAIR_NAME" \
-                    --instance-type m5.large \
+                    --instance-type "$AWS_INSTANCE_TYPE" \
                     --image-id "$(_find-ami)" \
                     --block-device-mappings "DeviceName=/dev/sda1,Ebs={VolumeSize=50,VolumeType=gp2}" \
                     --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$1}]" |

--- a/scripts/ubuntu-bartender/ubuntu-bartender
+++ b/scripts/ubuntu-bartender/ubuntu-bartender
@@ -99,9 +99,11 @@ fi
 # AWS SPECIFIC DEFAULTS
 AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-bionic-daily-amd64-server-*"
 AWS_PROFILE="default"
+AWS_INSTANCE_TYPE="m5.large"
 # Official Canonical OwnerId
 AWS_AMI_OWNER=099720109477
 AWS_KEYPAIR_NAME=$USER
+AWS_ARM_BUILD=false
 
 # MULTIPASS SPECIFIC DEFAULTS
 MULTIPASS_DISK_SIZE=50G
@@ -153,8 +155,9 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
                                             Value: Cleanup? $SHOULD_CLEANUP
 
     --aws-ami-name-filter <image-name>      Filter for finding an AWS ami by name
-                                            defaults to Xenial AMD64. This is
-                                            the base for the builds
+                                            defaults to Bionic AMD64. This is
+                                            the base for the builds. for ARM:
+                                            ubuntu/images-testing/hvm-ssd/ubuntu-bionic-daily-arm64-server-*
                                             Value: $AWS_AMI_NAME_FILTER
 
     --aws-profile <profile>                 AWS profile used with the aws cli
@@ -170,6 +173,14 @@ usage: $0 [<options>] -- --series <series> [<ubuntu-old-fashioned-options>]
                                             with chmod 400 in ~/.ssh/
                                             Default is $USER       
                                             Value: $AWS_KEYPAIR_NAME
+
+    --aws-instance-type                     EC2 instance type. default is m5.large.
+                                            m6g.large is a good choice for arm
+                                            value: $AWS_INSTANCE_TYPE
+
+    --aws-arm-build                         Short hand switch for safe arm64 defaults
+                                            This will override --aws-instance-type and --aws-ami-name-filter
+
     --temp-dir-loc                          Parent folder to build the temp dir used
                                             by bartender; note that this must be
                                             a directory that multipass (a strictly-
@@ -263,6 +274,13 @@ do
       AWS_KEYPAIR_NAME="$2"
       shift
       ;;
+    --aws-instance-type)
+      AWS_INSTANCE_TYPE="$2"
+      shift
+      ;;
+    --aws-arm-build)
+      AWS_ARM_BUILD=true
+      ;;
     --temp-dir-loc)
       TEMP_DIR_LOC="$2"
       shift
@@ -293,6 +311,12 @@ if [ "$SHOW_HELP" = "YES" ]
 then
   print-usage
   exit 255
+fi
+
+if [ "$AWS_ARM_BUILD" = "true" ]
+then
+  AWS_INSTANCE_TYPE="m6g.large"
+  AWS_AMI_NAME_FILTER="ubuntu/images-testing/hvm-ssd/ubuntu-bionic-daily-arm64-server-*"
 fi
 
 # Verify that the specified build provider is available and ready


### PR DESCRIPTION
To generate arm instances before, users would have to manually change
the aws instance type (when building on aws). Added a flag for
AWS_INSTANCE_TYPE to set via config. A wrapper flag to set safe defaults
for aws arm builds was also added.